### PR TITLE
[GitLab] Move Gitpod button to clone button

### DIFF
--- a/src/injectors/gitlab-injector.ts
+++ b/src/injectors/gitlab-injector.ts
@@ -44,29 +44,18 @@ export class GitlabInjector extends InjectorBase {
     }
 }
 
-// Layout:
-// <div class="project-clone-holder d-none d-md-inline-flex">
-//     <div class="git-clone-holder js-git-clone-holder input-group">
-//         <a class="input-group-text btn btn-primary btn-xs clone-dropdown-btn qa-clone-dropdown" data-toggle="dropdown" href="#" id="clone-dropdown" aria-expanded="false">
-//             <span class="append-right-4 js-clone-dropdown-label">
-//                 Clone
-//             </span>
-//             <svg class="icon"><use xlink:href="/assets/icons-5d6bba47cc3d399a160c22f8283b68e070717b97c9a35c0e3006d998b730b163.svg#arrow-down"></use></svg>
-//         </a>
-//         // ...
-//     </div>
-// </div>
 class RepositoryInjector implements ButtonInjector {
-    static readonly PARENT_SELECTOR = ".project-repo-buttons";
+    static readonly PARENT_SELECTOR = ".tree-controls";
 
     isApplicableToCurrentPage(): boolean {
-        const result = !!select.exists(RepositoryInjector.PARENT_SELECTOR);
+        const result = !!select.exists(RepositoryInjector.PARENT_SELECTOR)
+            && !!select.exists(".project-clone-holder");
         return result;
     }
 
     inject(currentUrl: string) {
-        const projectRepoButtons = select(RepositoryInjector.PARENT_SELECTOR);
-        if (!projectRepoButtons) {
+        const parent = select(RepositoryInjector.PARENT_SELECTOR);
+        if (!parent || !parent.firstElementChild) {
             return;
         }
 
@@ -78,16 +67,16 @@ class RepositoryInjector implements ButtonInjector {
         }
 
         const btn = this.renderButton(currentUrl);
-        projectRepoButtons.appendChild(btn);
+        console.log(parent.innerHTML);
+        parent.firstElementChild.appendChild(btn);
     }
 
     protected renderButton(url: string): HTMLElement {
         const container = document.createElement('div');
-        container.className = "project-clone-holder d-none d-md-inline-flex";
-        container.style.marginLeft = '8px'; // The only thing not copied from the clone button
+        container.className = "project-clone-holder d-none d-md-inline-block";
 
         const container2ndLevel = document.createElement('div');
-        container2ndLevel.className = "git-clone-holder js-git-clone-holder input-group";
+        container2ndLevel.className = "git-clone-holder js-git-clone-holder";
 
         const a = document.createElement('a');
         a.id = Gitpodify.BTN_ID;
@@ -95,7 +84,7 @@ class RepositoryInjector implements ButtonInjector {
         a.text = "Gitpod"
         a.href = url;
         a.target = "_blank";
-        a.className = "input-group-text btn btn-primary btn-xs";
+        a.className = "btn btn-primary";
 
         container2ndLevel.appendChild(a);
         container.appendChild(container2ndLevel);


### PR DESCRIPTION
With this PR the Gitpod button is next to the clone button.



## This is how it has been looked like before this PR:

![image](https://user-images.githubusercontent.com/24960040/76796306-6cd2d580-67cb-11ea-812b-82ad0e670f7f.png)



## Now the Gitpod button is next to the clone button:

![image](https://user-images.githubusercontent.com/24960040/76796505-dd79f200-67cb-11ea-96fd-c610cb7abfa8.png)


## Bonus:
With this change you get the Gitpod button in the Repository Files view for free. It opens the selected branch in Gitpod:
![image](https://user-images.githubusercontent.com/24960040/76796643-3184d680-67cc-11ea-879b-bc990c657522.png)
