### PR TITLE
Update Browser Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*.log
 dist
+gitpod.xpi
 node_modules

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,2 @@
 tasks:
-- init: yarn install && yarn build
+  - init: yarn install && yarn build && yarn package

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Gitpod Browser extension
 [![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/browser-extension)
 
-This is the browser extension for Gitpod, supporting Chrome and Firefox. It adds a **Gitpod** button to the configured GitHub and GitLab installations (defaults to domains containing `github.com` or `gitlab.com`) which directly creates a workspace for that context:
+This is the browser extension for Gitpod, supporting Chrome ([Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)) and Firefox ([Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)). It adds a **Gitpod** button to the configured GitHub and GitLab installations (defaults to domains containing `github.com` or `gitlab.com`) which directly creates a workspace for that context:
 
  ![Gitpodify](./docs/github-injected.png "Gitpodify")
 
 ## Build
 
 ```
-yarn install && yarn build
+yarn install && yarn build && yarn package
 ```
 
 ## Test
 
-[Build](#build) first and then load it as ["unpackaged extension" (Chrome)](https://developer.chrome.com/extensions/getstarted#unpacked) or ["temporary add-on" (Firefox)](https://blog.mozilla.org/addons/2015/12/23/loading-temporary-add-ons/). It should be active until the next restart of your browser.
+[Build](#build) the extension and
+* unzip `gitpod.xpi` and load it as [“unpackaged extension” (Chrome)](https://developer.chrome.com/extensions/getstarted) or
+* load `gitpod.xpi` as [“temporary add-on” (Firefox)](https://blog.mozilla.org/addons/2015/12/23/loading-temporary-add-ons/).
+
+The extension is active until the next restart of your browser.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gitpod Online IDE",
   "short_name": "Gitpod",
   "version": "1.2",
-  "description": "Gitpod - One-Click Online IDE for GitHub, GitLab and Bitbucket",
+  "description": "Gitpod – One-Click Online IDE for GitHub, GitLab and Bitbucket",
   "icons": {
     "16": "icons/gitpod-logo-16.png",
     "48": "icons/gitpod-logo-48.png",
@@ -12,7 +12,10 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "*://*.github.com/*",
+        "*://*.gitlab.com/*",
+        "*://*.bitbucket.org/*",
+        "*://*.gitpod.io/*"
       ],
       "js": [
         "dist/bundles/gitpodify.bundle.js"
@@ -25,13 +28,16 @@
       "48": "icons/gitpod-logo-48.png",
       "128": "icons/gitpod-logo.png"
     },
-    "default_title": "Gitpod",
-    "default_popup": "src/options/options.html"
+    "default_title": "Gitpod Online IDE"
+  },
+  "background": {
+    "scripts": ["dist/bundles/background.bundle.js"]
   },
   "options_ui": {
     "page": "src/options/options.html"
   },
   "permissions": [
+    "activeTab",
     "storage"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "name": "gitpod-web-extension",
   "version": "0.0.1",
   "license": "MIT",
-  "description": "Browser extension (Chrome/Firefox) for Enhancing Github and Gitlab with Gitpod links",
+  "description": "Browser extension (Chrome/Firefox) for enhancing GitHub, GitLab and Bitbucket with Gitpod links",
   "main": "src/gitpodify.js",
   "scripts": {
     "build": "yarn clean && npx tsc && yarn webpack",
-    "clean": "rimraf dist",
+    "package": "yarn clean:package && zip -rD --exclude='src/*.ts' gitpod.xpi dist/bundles icons src manifest.json",
+    "clean": "rimraf dist && yarn clean:package",
+    "clean:package": "rimraf gitpod.xpi",
     "webpack": "webpack",
     "watch": "webpack -w"
   },

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,20 @@
+import { browser } from "webextension-polyfill-ts";
+import { ConfigProvider } from "./config";
+
+async function gitpodifyCurrentTab() {
+    try {
+        // add a dummy div element to indicate that gitpodify.bundle.js was injected by a user click on the gitpod icon
+        browser.tabs.executeScript({ code: "document.body.innerHTML += '<div style=\"display: none;\" id=\"gitpod-extension-icon-clicked\"></div>'" })
+        browser.tabs.executeScript({ file: "/dist/bundles/gitpodify.bundle.js" });
+    } catch {
+        try {
+            const configProvider = await ConfigProvider.create();
+            const config = configProvider.getConfig();
+            window.open(config.gitpodURL);
+        } catch {
+            window.open("https://gitpod.io");
+        }
+    }
+}
+
+browser.browserAction.onClicked.addListener(gitpodifyCurrentTab)

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,12 +3,10 @@ import { EventEmitter } from "events";
 
 export interface Config {
     gitpodURL: string;
-    injectIntoDomains: string[];
 }
 
 export const DEFAULT_CONFIG: Config = {
-    gitpodURL: "https://gitpod.io",
-    injectIntoDomains: ["github.com","gitlab.com"]
+    gitpodURL: "https://gitpod.io"
 };
 
 export interface ConfigListener {

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -49,7 +49,9 @@ export class GitHubInjector extends InjectorBase {
     async inject(): Promise<void> {
         // ghInjection triggers an event whenever only parts of the GitHub page have been reloaded
 	    ghInjection(() => {
-            this.injectButtons()
+            if (!this.checkIsInjected()) {
+                this.injectButtons();
+            }
         });
     }
 
@@ -75,9 +77,12 @@ abstract class ButtonInjectorBase implements ButtonInjector {
         }
 
         const oldBtn = document.getElementById(Gitpodify.NAV_BTN_ID);
-        if (oldBtn && !checkIsBtnUpToDate(oldBtn, currentUrl)) {
-            // Only add once
-            (oldBtn as HTMLAnchorElement).href = currentUrl;
+        if (oldBtn) {
+            if (!checkIsBtnUpToDate(oldBtn, currentUrl)) {
+                // update button
+                (oldBtn as HTMLAnchorElement).href = currentUrl;
+            }
+            // button is there and up-to-date
             return;
         }
 

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -2,6 +2,7 @@ import * as select from 'select-dom';
 import * as ghInjection from 'github-injection';
 import { ConfigProvider } from '../config';
 import { ButtonInjector, InjectorBase, checkIsBtnUpToDate } from './injector';
+import { renderGitpodUrl } from '../utils';
 
 namespace Gitpodify {
 	export const NAV_BTN_ID = "gitpod-btn-nav";
@@ -41,7 +42,7 @@ export class GitHubInjector extends InjectorBase {
 
     checkIsInjected(): boolean {
         const button = document.getElementById(`${Gitpodify.NAV_BTN_ID}`);
-        const currentUrl = this.renderGitpodUrl();
+        const currentUrl = renderGitpodUrl(this.config.gitpodURL);
         return checkIsBtnUpToDate(button, currentUrl);
     }
 

--- a/src/injectors/gitlab-injector.ts
+++ b/src/injectors/gitlab-injector.ts
@@ -2,6 +2,7 @@ import * as domloaded from 'dom-loaded';
 import * as select from 'select-dom';
 import { ConfigProvider } from '../config';
 import { ButtonInjector, InjectorBase, checkIsBtnUpToDate } from './injector';
+import { renderGitpodUrl } from '../utils';
 
 namespace Gitpodify {
 	export const BTN_ID = "gitpod-btn-nav";
@@ -29,7 +30,7 @@ export class GitlabInjector extends InjectorBase {
 
     checkIsInjected(): boolean {
         const button = document.getElementById(`${Gitpodify.BTN_ID}`);
-        const currentUrl = this.renderGitpodUrl();
+        const currentUrl = renderGitpodUrl(this.config.gitpodURL);
         return checkIsBtnUpToDate(button, currentUrl);
     }
 

--- a/src/injectors/injector.ts
+++ b/src/injectors/injector.ts
@@ -1,4 +1,5 @@
 import { ConfigProvider } from "../config";
+import { renderGitpodUrl } from "../utils";
 
 export interface Injector {
 
@@ -50,7 +51,7 @@ export abstract class InjectorBase implements Injector {
     abstract update(): Promise<void>;
 
     injectButtons(singleInjector: boolean = false) {
-        const currentUrl = this.renderGitpodUrl();
+        const currentUrl = renderGitpodUrl(this.config.gitpodURL);
         for (const injector of this.buttonInjectors) {
             if (injector.isApplicableToCurrentPage()) {
                 injector.inject(currentUrl);
@@ -60,12 +61,6 @@ export abstract class InjectorBase implements Injector {
             }
         }
     };
-
-    // Helpers
-    protected renderGitpodUrl(): string {
-        const baseURL = `${window.location.protocol}//${window.location.host}`;
-        return `${this.config.gitpodURL}#${baseURL}` + window.location.pathname;
-    }
 
     protected get config() {
         return this.configProvider.getConfig();

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -17,7 +17,8 @@ div#content > div.row {
   align-items: center;
 }
 
-.row > label {
+.row {
+    margin-bottom: .5em;
 }
 
 .row > input {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -7,12 +7,13 @@
     <body>
         <div id="content">
             <div class="row">
-                <label>Gitpod Installation URL</label>
+                <label>Gitpod installation URL:</label>
                 <input id="gitpod-url-input" type="url" value=""/>
             </div>
             <div class="row">
-                <label>Inject into Domains</label>
-                <input id="injection-domains-input" type="text" value=""/>
+                <div style="min-width: 5em;"></div>
+                <div><a href="https://www.gitpod.io/docs/browser-extension/">https://www.gitpod.io/docs/browser-extension/</a></div>
+                <div id="message" style="min-width: 5em;"></div>
             </div>
         </div>
         <script src="../../dist/bundles/options.bundle.js"></script>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,9 +1,7 @@
 import { ConfigProvider } from "../config";
 
-const SEPARATOR = ",";
-
 const gitpodUrlInput = document.getElementById("gitpod-url-input")! as HTMLInputElement;
-const domainPatternsInput = document.getElementById("injection-domains-input")! as HTMLInputElement;
+const messageElement = document.getElementById("message")! as HTMLDivElement;
 
 
 const init = async () => {
@@ -12,7 +10,8 @@ const init = async () => {
     // Initialize UI
     const initialConfig = configProvider.getConfig();
     gitpodUrlInput.value = initialConfig.gitpodURL;
-    domainPatternsInput.value = initialConfig.injectIntoDomains.join(SEPARATOR);
+
+    let timeout: number | undefined = undefined;
 
     // Save config before close
     const saveOnType = (event: KeyboardEvent) => {
@@ -20,17 +19,18 @@ const init = async () => {
             return;
         }
 
-        const domainPatternsStr = domainPatternsInput.value || "";
-        const domainPatterns = domainPatternsStr.split(SEPARATOR);
-
         // Update config (propagated internally)
         configProvider.setConfig({
             gitpodURL: gitpodUrlInput.value || undefined,
-            injectIntoDomains: domainPatterns,
         });
+        if (timeout) {
+            window.clearTimeout(timeout);
+            timeout = undefined;
+        }
+        messageElement.innerText = "Saved.";
+        timeout = window.setTimeout(() => { messageElement.innerText = ""; timeout = undefined }, 3000);
     };
     gitpodUrlInput.addEventListener("keyup", saveOnType);
-    domainPatternsInput.addEventListener("keyup", saveOnType);
 };
 
 init().catch(err => console.error(err));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,4 @@
+export function renderGitpodUrl(gitpodURL: string): string {
+    const baseURL = `${window.location.protocol}//${window.location.host}`;
+    return `${gitpodURL}/#${baseURL}` + window.location.pathname;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,9 @@
             "es6",
             "dom"
         ],
-        "sourceMap": true,
-        "declaration": true,
-        "declarationMap": true,
+        "sourceMap": false,
+        "declaration": false,
+        "declarationMap": false,
         "skipLibCheck": true
     },
     "include": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,10 +21,7 @@ module.exports = {
                 test: /\.js$/,
                 exclude: /node_modules/,
                 enforce: 'pre',
-                loader: 'source-map-loader'
             }
         ]
     }
 };
-
-module.exports.devtool = 'source-map';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
     entry: {
         gitpodify: './dist/gitpodify.js',
         options: './dist/options/options.js',
+        background: './dist/background.js'
     },
     output: {
         filename: 'bundles/[name].bundle.js',


### PR DESCRIPTION
The current state in master is not in the extension stores (Chrome/Firefox) because it requires the rights to read every website. This PR updates the browser extension with the goal to bring a new version in the extension stores (with more conservative rights than the master state). The changes are:

- Deactivating the generation of SourceMap 96b277f since they are not delivered by the plugin and lead to log entries (fixes #10).
- Asks for accessing gitpod.io, github.com, gitlab.com and bitbucket.com (the latter for for future releases) instead of accessing all websites.
- In contrast to the extension in the extension stores it injects a button to gitlab.com as well (fixes #11 – however technically it is not a change of this PR but this PR enables to bring this into the extension stores).
- In order to support self-hosted GitHub, GitLab or BitBucket installations without asking to read every website this PR brings in the following compromise: It adds the permission to read the current tab when a user clicks on the Gitpod icon in the extensions bar (`activeTab` permission). If you configure another GitHoster installation in the options (see screenshot below) and click on the Gitpod extension toolbar icon the Gitpod button is injected in the current tab (when the domain matches one of the configured domains). Since this introduces the need for a second click (first on the Gitpod extensions toolbar icon and second on the injected Gitpod button on the page) users can configure in the options that Gitpod is opened with the active tab as context (when one of the configured domains matches) directly on click (see second screenshot). In all other cases the Gitpod installation URL is opened on Gitpod extension toolbar icon click.

![image](https://user-images.githubusercontent.com/24960040/83499766-25044600-a4be-11ea-8208-3cfd435b30d2.png)
![image](https://user-images.githubusercontent.com/24960040/83500161-b07dd700-a4be-11ea-907f-8228b380d428.png)

Fixes #9.

### Limitations:
- Firefox blocks opening Gitpod as popup.

### Follow-ups:
- Update extensions doc to explain the new behavior.

### Download browser extensions to test in Chrome/Firefox:
- [gitpod-browser-extensions.zip](https://github.com/gitpod-io/browser-extension/files/4722110/gitpod-browser-extensions.zip)
- (see README.md for instructions)

EDIT: `gitpod-browser-extensions.zip` updated