### PR TITLE
Adding Edge support mention in README and package.json + Bitbucket support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gitpod Browser extension
 [![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/browser-extension)
 
-This is the browser extension for Gitpod, supporting Chrome ([Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Edge (since it supports Chrome extensions, [see how](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)) and Firefox ([Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)). It adds a **Gitpod** button to the configured GitHub and GitLab installations (defaults to domains containing `github.com` or `gitlab.com`) which directly creates a workspace for that context:
+This is the browser extension for Gitpod, supporting Chrome ([Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Edge (since it supports Chrome extensions, [see how](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)) and Firefox ([Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)). It adds a **Gitpod** button to the configured GitHub, GitLab and BitBucket installations (defaults to domains containing `github.com`, `gitlab.com` or `bitbucket.org`) which directly creates a workspace for that context:
 
  ![Gitpodify](./docs/github-injected.png "Gitpodify")
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gitpod Browser extension
 [![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/browser-extension)
 
-This is the browser extension for Gitpod, supporting Chrome ([Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Edge (since it supports Chrome extensions, [see how](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)) and Firefox ([Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)). It adds a **Gitpod** button to the configured GitHub, GitLab and BitBucket installations (defaults to domains containing `github.com`, `gitlab.com` or `bitbucket.org`) which directly creates a workspace for that context:
+This is the browser extension for Gitpod. It supports Chrome (see [Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Firefox (see [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)) and Edge (see [how to install Chrome extensions](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)), and adds a **Gitpod** button to the configured GitLab, GitHub and Bitbucket installations (defaults to `gitlab.com`, `github.com` and `bitbucket.org`) which immediately creates a Gitpod workspace for the current Git context:
 
  ![Gitpodify](./docs/github-injected.png "Gitpodify")
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gitpod Browser extension
 [![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/browser-extension)
 
-This is the browser extension for Gitpod, supporting Chrome ([Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)) and Firefox ([Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)). It adds a **Gitpod** button to the configured GitHub and GitLab installations (defaults to domains containing `github.com` or `gitlab.com`) which directly creates a workspace for that context:
+This is the browser extension for Gitpod, supporting Chrome ([Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Edge (since it supports Chrome extensions, [see how](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)) and Firefox ([Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)). It adds a **Gitpod** button to the configured GitHub and GitLab installations (defaults to domains containing `github.com` or `gitlab.com`) which directly creates a workspace for that context:
 
  ![Gitpodify](./docs/github-injected.png "Gitpodify")
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "gitpod-web-extension",
   "version": "0.0.1",
   "license": "MIT",
-  "description": "Browser extension (Chrome/Firefox) for enhancing GitHub, GitLab and Bitbucket with Gitpod links",
+  "description": "Browser extension (Chrome/Edge/Firefox) for enhancing GitHub, GitLab and Bitbucket with Gitpod links",
   "main": "src/gitpodify.js",
   "scripts": {
     "build": "yarn clean && npx tsc && yarn webpack",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "gitpod-web-extension",
   "version": "0.0.1",
   "license": "MIT",
-  "description": "Browser extension (Chrome/Edge/Firefox) for enhancing GitHub, GitLab and Bitbucket with Gitpod links",
+  "description": "Browser extension (Chrome/Firefox/Edge) for enhancing GitLab, GitHub and Bitbucket with Gitpod links",
   "main": "src/gitpodify.js",
   "scripts": {
     "build": "yarn clean && npx tsc && yarn webpack",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "gitpod-web-extension",
   "version": "0.0.1",
   "license": "MIT",
-  "description": "Browser extension (Chrome/Firefox/Edge) for enhancing GitLab, GitHub and Bitbucket with Gitpod links",
+  "description": "Browser extension (Chrome/Firefox/Edge) for enhancing GitLab, GitHub and Bitbucket with Gitpod buttons",
   "main": "src/gitpodify.js",
   "scripts": {
     "build": "yarn clean && npx tsc && yarn webpack",


### PR DESCRIPTION
## Edge support

Since Edge supports Chrome extensions out of the box, this means that your extension is de facto supported on Edge browsers.

You may also want to add this in this repo's About in GitHub, which only mentions Chrome and Firefox.

## Bitbucket support

Add mention of Bitbucket support in README