### PR TITLE
Update button class names for GitLab

### DIFF
--- a/src/injectors/gitlab-injector.ts
+++ b/src/injectors/gitlab-injector.ts
@@ -95,7 +95,7 @@ class RepositoryInjector implements ButtonInjector {
         a.text = "Gitpod"
         a.href = url;
         a.target = "_blank";
-        a.className = "btn btn-primary";
+        a.className = "gl-button btn btn-info";
         
         if (openAsPopup) {
             makeOpenInPopup(a);


### PR DESCRIPTION
This will update the class names used for the button injected in GitLab to match the new button styles of the near buttons.

For more context, see [relevant migration epic](https://gitlab.com/groups/gitlab-org/-/epics/3459).

| BEFORE | AFTER  |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/100198957-39714a80-2f05-11eb-946b-d93e0c2ffadc.png) | ![image](https://user-images.githubusercontent.com/120486/100198971-3d04d180-2f05-11eb-9842-31390e22c1c1.png) |
| ![image](https://user-images.githubusercontent.com/120486/100198994-42621c00-2f05-11eb-8b2f-fed8339b8b46.png) | ![image](https://user-images.githubusercontent.com/120486/100199009-455d0c80-2f05-11eb-9667-c28c963f9965.png) |