### PR TITLE
don't render button at the bottom of the page!

### DIFF
--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -167,7 +167,7 @@ class IssueInjector extends ButtonInjectorBase {
 
 class FileInjector extends ButtonInjectorBase {
     constructor() {
-        super(".repository-content > div", "gitpod-file-btn");
+        super(".repository-content > div > div", "gitpod-file-btn");
     }
 
     protected adjustButton(a: HTMLAnchorElement): void {


### PR DESCRIPTION
If you check out any file page, you'll see the Gitpod button at the bottom. This is because a div was added in the HTML between the .repository-content and the action bar.  This quick fix just inserts a diff back in the selector chain.