### PR TITLE
Added PreBuild Button configurable from Preference

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,13 @@ import { EventEmitter } from "events";
 export interface Config {
     gitpodURL: string;
     openAsPopup: boolean;
+    isEnabledPrebuildButton: boolean;
 }
 
 export const DEFAULT_CONFIG: Config = {
     gitpodURL: "https://gitpod.io",
-    openAsPopup: false
+    openAsPopup: false,
+    isEnabledPrebuildButton: false,
 };
 
 export interface ConfigListener {

--- a/src/injectors/gitlab-injector.ts
+++ b/src/injectors/gitlab-injector.ts
@@ -55,7 +55,7 @@ class RepositoryInjector implements ButtonInjector {
         return result;
     }
 
-    inject(currentUrl: string, openAsPopup: boolean) {
+    inject(currentUrl: string, openAsPopup: boolean, isEnabledPrebuildButton: boolean) {
         const parent = select(RepositoryInjector.PARENT_SELECTOR);
         if (!parent || !parent.firstElementChild) {
             return;
@@ -68,7 +68,7 @@ class RepositoryInjector implements ButtonInjector {
             return;
         }
 
-        const btn = this.renderButton(currentUrl, openAsPopup);
+        const btn = this.renderButton(currentUrl, openAsPopup, isEnabledPrebuildButton);
         parent.firstElementChild.appendChild(btn);
 
         const primaryButtons = parent.firstElementChild.getElementsByClassName("btn-primary");
@@ -82,7 +82,7 @@ class RepositoryInjector implements ButtonInjector {
         }
     }
 
-    protected renderButton(url: string, openAsPopup: boolean): HTMLElement {
+    protected renderButton(url: string, openAsPopup: boolean, isEnabledPrebuildButton: boolean): HTMLElement {
         const container = document.createElement('div');
         container.className = "project-clone-holder d-none d-md-inline-block";
 
@@ -96,12 +96,24 @@ class RepositoryInjector implements ButtonInjector {
         a.href = url;
         a.target = "_blank";
         a.className = "gl-button btn btn-info";
-        
+
         if (openAsPopup) {
             makeOpenInPopup(a);
         }
 
         container2ndLevel.appendChild(a);
+
+        if(isEnabledPrebuildButton){
+            const pb = document.createElement('a');
+            pb.id = Gitpodify.BTN_ID;
+            pb.title = "PreBuild";
+            pb.text = "PreBuild"
+            pb.href = url.replace("#","#prebuild/");
+            pb.target = "_blank";
+            pb.className = "gl-button btn btn-info";
+            container2ndLevel.appendChild(pb)
+        }
+        
         container.appendChild(container2ndLevel);
         return container;
     }

--- a/src/injectors/injector.ts
+++ b/src/injectors/injector.ts
@@ -36,7 +36,7 @@ export interface ButtonInjector {
      * Injects the actual button
      * @param currentUrl The currently configured Gitpod URL
      */
-    inject(currentUrl: string, openAsPopup: boolean): void;
+    inject(currentUrl: string, openAsPopup: boolean, isEnabledPrebuildButton:boolean): void;
 }
 
 export abstract class InjectorBase implements Injector {
@@ -54,7 +54,7 @@ export abstract class InjectorBase implements Injector {
         const currentUrl = renderGitpodUrl(this.config.gitpodURL);
         for (const injector of this.buttonInjectors) {
             if (injector.isApplicableToCurrentPage()) {
-                injector.inject(currentUrl, this.config.openAsPopup);
+                injector.inject(currentUrl, this.config.openAsPopup, this.config.isEnabledPrebuildButton);
                 if (singleInjector) {
                     break;
                 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,6 +11,10 @@
                 <input id="gitpod-url-input" type="url" value=""/>
             </div>
             <div class="row">
+                <label>Show PreBuild Option:</label>
+                <input id="gitpod-is-enabled-prebuild-button" type="checkbox" value=""/>
+            </div>
+            <div class="row">
                 <label>Open as popup:</label>
                 <input id="gitpod-open-as-popup" type="checkbox"/>
             </div>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,6 +1,7 @@
 import { ConfigProvider } from "../config";
 
 const gitpodUrlInput = document.getElementById("gitpod-url-input")! as HTMLInputElement;
+const gitpodPrebuildButtonEnabled = document.getElementById("gitpod-is-enabled-prebuild-button") as HTMLInputElement;
 const gitpodPopupInput = document.getElementById("gitpod-open-as-popup")! as HTMLInputElement;
 const messageElement = document.getElementById("message")! as HTMLDivElement;
 
@@ -12,6 +13,7 @@ const init = async () => {
     const initialConfig = configProvider.getConfig();
     gitpodUrlInput.value = initialConfig.gitpodURL;
     gitpodPopupInput.checked = initialConfig.openAsPopup;
+    gitpodPrebuildButtonEnabled.checked =  initialConfig.isEnabledPrebuildButton;
 
     let timeout: number | undefined = undefined;
 
@@ -20,7 +22,8 @@ const init = async () => {
         // Update config (propagated internally)
         configProvider.setConfig({
             gitpodURL: gitpodUrlInput.value || undefined,
-            openAsPopup: gitpodPopupInput.checked
+            openAsPopup: gitpodPopupInput.checked,
+            isEnabledPrebuildButton: gitpodPrebuildButtonEnabled.checked
         });
         if (timeout) {
             window.clearTimeout(timeout);
@@ -36,6 +39,7 @@ const init = async () => {
         save() 
     });
     gitpodPopupInput.addEventListener('change', save);
+    gitpodPrebuildButtonEnabled.addEventListener('change', save);
 };
 
 init().catch(err => console.error(err));


### PR DESCRIPTION
## Description
Added a Prebuild Button configurable from the Preference section of the plugin. Non-Github users can now initiate prebuild with one click. 

## Related Issue(s)
None

## How to test
1. Install the Extension in your Browser
2. Go to Manage Extension Page and then on preferences
3. Check "Show PreBuild Option"
4. Visit any repository on gitlab.com
5. You will now see two extra buttons on the repository, one for opening the repository in Gitpod and another one for starting the pre-build of the repository. 


<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
