### PR TITLE
Include track params in redirect to website

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -21,7 +21,7 @@ browser.browserAction.onClicked.addListener(gitpodifyCurrentTab)
 
 browser.runtime.onInstalled.addListener((details) => {
     if (details.reason === "install") {
-        window.open("https://www.gitpod.io/extension-activation/");
+        window.open("https://www.gitpod.io/extension-activation?track=true");
     }
 });
-browser.runtime.setUninstallURL("https://www.gitpod.io/extension-uninstall/");
+browser.runtime.setUninstallURL("https://www.gitpod.io/extension-uninstall?track=true");


### PR DESCRIPTION
Includes track params when user is redirected to Website so that install/uninstall is tracked.
Relates to [#1392](https://github.com/gitpod-io/website/pull/1392) of the website and issue [#6974](https://github.com/gitpod-io/gitpod/issues/6974).