### PR TITLE
fix: :bug: gitpodify url ignores search params

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Gitpod - Always ready to code",
   "short_name": "Gitpod",
-  "version": "1.11",
+  "version": "1.12",
   "description": "Spin up fresh, automated dev environments for each task, in the cloud, in seconds.",
   "icons": {
     "16": "icons/gitpod-logo-16.png",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 export function renderGitpodUrl(gitpodURL: string): string {
     const baseURL = `${window.location.protocol}//${window.location.host}`;
-    return `${gitpodURL}/#${baseURL}` + window.location.pathname;
+    return `${gitpodURL}/#${baseURL}` + window.location.pathname + window.location.search;
 }
 
 export function makeOpenInPopup(a: HTMLAnchorElement): void {


### PR DESCRIPTION
While gitpodify a url, search params are getting ignored.

Bitbucket uses search params `at` as the branch name. `https://bitbucket.org/<org>/<repo>/src/<commit-has>/?at=<branch-name>`

When gitpodify such url, it leads to incorrect context parsing and open workspace in invalid state.

previously

`https://gitpod.io/#https://bitbucket.org/<org>/<repo>/src/<commit-hash>`

context 
```
{
    ...........
   "ref": <commit-hash>,
   "refType": "commit"
}
```
Now
`https://gitpod.io/#https://bitbucket.org/<org>/<repo>/src/<commit-hash>?at=<branch-name>`

context: 
```
{
    ...........................
    ref: "<branch-name>",
    refType: "branch"
}
```
close https://github.com/gitpod-io/gitpod/issues/7922