### PR TITLE
Make it possible to open gitpod.io instead of github.dev

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,13 @@ import { EventEmitter } from "events";
 export interface Config {
     gitpodURL: string;
     openAsPopup: boolean;
+    rewritePeriodKeybind: boolean;
 }
 
 export const DEFAULT_CONFIG: Config = {
     gitpodURL: "https://gitpod.io",
-    openAsPopup: false
+    openAsPopup: false,
+    rewritePeriodKeybind: true
 };
 
 export interface ConfigListener {

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -2,7 +2,7 @@ import * as select from 'select-dom';
 import * as ghInjection from 'github-injection';
 import { ConfigProvider } from '../config';
 import { ButtonInjector, InjectorBase, checkIsBtnUpToDate } from './injector';
-import { renderGitpodUrl, makeOpenInPopup } from '../utils';
+import { renderGitpodUrl, makeOpenInPopup, isVisible } from '../utils';
 
 namespace Gitpodify {
 	export const NAV_BTN_ID = "gitpod-btn-nav";
@@ -52,6 +52,23 @@ export class GitHubInjector extends InjectorBase {
             if (!this.checkIsInjected()) {
                 this.injectButtons();
             }
+                
+            document.querySelectorAll('.js-github-dev-shortcut, .js-github-dev-new-tab-shortcut').forEach((elem) => {
+                const new_element = elem.cloneNode(true);
+                //@ts-ignore
+                elem.parentNode.replaceChild(new_element, elem);
+                new_element.addEventListener('click', (e) => {
+                    //@ts-ignore
+                    if (new_element && isVisible(new_element) && !confirm('Are you sure you want to open github.dev?')) {
+                        return;
+                    }
+                    const currentUrl = window.location.href;
+                    window.open(`https://gitpod.io/#${currentUrl}`, elem.classList.contains('js-github-dev-new-tab-shortcut') ? '_blank' : '_self');
+                    e.preventDefault();
+                    e.stopPropagation();
+                });
+                console.debug('Injected rewrite');
+            });
         });
     }
 

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -1,8 +1,8 @@
 import * as select from 'select-dom';
 import * as ghInjection from 'github-injection';
 import { ConfigProvider } from '../config';
-import { ButtonInjector, InjectorBase, checkIsBtnUpToDate } from './injector';
-import { renderGitpodUrl, makeOpenInPopup, isVisible } from '../utils';
+import { ButtonInjector, InjectorBase, checkIsBtnUpToDate, rewritePeriodKeybind } from './injector';
+import { renderGitpodUrl, makeOpenInPopup } from '../utils';
 
 namespace Gitpodify {
 	export const NAV_BTN_ID = "gitpod-btn-nav";
@@ -52,23 +52,10 @@ export class GitHubInjector extends InjectorBase {
             if (!this.checkIsInjected()) {
                 this.injectButtons();
             }
-                
-            document.querySelectorAll('.js-github-dev-shortcut, .js-github-dev-new-tab-shortcut').forEach((elem) => {
-                const new_element = elem.cloneNode(true);
-                //@ts-ignore
-                elem.parentNode.replaceChild(new_element, elem);
-                new_element.addEventListener('click', (e) => {
-                    //@ts-ignore
-                    if (new_element && isVisible(new_element) && !confirm('Are you sure you want to open github.dev?')) {
-                        return;
-                    }
-                    const currentUrl = window.location.href;
-                    window.open(`https://gitpod.io/#${currentUrl}`, elem.classList.contains('js-github-dev-new-tab-shortcut') ? '_blank' : '_self');
-                    e.preventDefault();
-                    e.stopPropagation();
-                });
-                console.debug('Injected rewrite');
-            });
+            
+            (async () => {
+               await rewritePeriodKeybind();
+            })();
         });
     }
 

--- a/src/injectors/injector.ts
+++ b/src/injectors/injector.ts
@@ -1,5 +1,6 @@
 import { ConfigProvider } from "../config";
 import { renderGitpodUrl } from "../utils";
+import { isVisible } from "../utils";
 
 export interface Injector {
 
@@ -64,6 +65,29 @@ export abstract class InjectorBase implements Injector {
 
     protected get config() {
         return this.configProvider.getConfig();
+    }
+}
+
+export async function rewritePeriodKeybind() {
+    const configProvider = await ConfigProvider.create();
+    const config = configProvider.getConfig();
+
+    if (config.rewritePeriodKeybind) {
+        document.querySelectorAll('.js-github-dev-shortcut, .js-github-dev-new-tab-shortcut').forEach((elem) => {
+            const new_element = elem.cloneNode(true);
+            //@ts-ignore
+            elem.parentNode.replaceChild(new_element, elem);
+            new_element.addEventListener('click', (e) => {
+                //@ts-ignore
+                if (new_element && isVisible(new_element) && !confirm('Are you sure you want to open github.dev?')) {
+                    return;
+                }
+                const currentUrl = window.location.href;
+                window.open(`https://gitpod.io/#${currentUrl}`, elem.classList.contains('js-github-dev-new-tab-shortcut') ? '_blank' : '_self');
+                e.preventDefault();
+                e.stopPropagation();
+            });
+        });
     }
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -15,6 +15,10 @@
                 <input id="gitpod-open-as-popup" type="checkbox"/>
             </div>
             <div class="row">
+                <label>Replace <kbd>.</kbd> keybind:</label>
+                <input id="gitpod-replace-keybind" type="checkbox"/>
+            </div>
+            <div class="row">
                 <div style="min-width: 5em;"></div>
                 <div><a href="https://www.gitpod.io/docs/browser-extension/">https://www.gitpod.io/docs/browser-extension/</a></div>
                 <div id="message" style="min-width: 5em;"></div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -15,7 +15,7 @@
                 <input id="gitpod-open-as-popup" type="checkbox"/>
             </div>
             <div class="row">
-                <label>Replace <kbd>.</kbd> keybind:</label>
+                <label>Replace <kbd>.</kbd> keybind (opens Gitpod instead of vscode.dev):</label>
                 <input id="gitpod-replace-keybind" type="checkbox"/>
             </div>
             <div class="row">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,6 +1,7 @@
 import { ConfigProvider } from "../config";
 
 const gitpodUrlInput = document.getElementById("gitpod-url-input")! as HTMLInputElement;
+const gitpodRewriteKeybind = document.getElementById("gitpod-replace-keybind")! as HTMLInputElement;
 const gitpodPopupInput = document.getElementById("gitpod-open-as-popup")! as HTMLInputElement;
 const messageElement = document.getElementById("message")! as HTMLDivElement;
 
@@ -12,6 +13,7 @@ const init = async () => {
     const initialConfig = configProvider.getConfig();
     gitpodUrlInput.value = initialConfig.gitpodURL;
     gitpodPopupInput.checked = initialConfig.openAsPopup;
+    gitpodRewriteKeybind.checked = initialConfig.rewritePeriodKeybind;
 
     let timeout: number | undefined = undefined;
 
@@ -20,7 +22,8 @@ const init = async () => {
         // Update config (propagated internally)
         configProvider.setConfig({
             gitpodURL: gitpodUrlInput.value || undefined,
-            openAsPopup: gitpodPopupInput.checked
+            openAsPopup: gitpodPopupInput.checked,
+            rewritePeriodKeybind: gitpodRewriteKeybind.checked
         });
         if (timeout) {
             window.clearTimeout(timeout);
@@ -35,7 +38,7 @@ const init = async () => {
         }
         save() 
     });
-    gitpodPopupInput.addEventListener('change', save);
+    [gitpodPopupInput, gitpodPopupInput, gitpodRewriteKeybind].forEach((el) => el.addEventListener('change', save))
 };
 
 init().catch(err => console.error(err));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,19 @@ export function renderGitpodUrl(gitpodURL: string): string {
     return `${gitpodURL}/#${baseURL}` + window.location.pathname + window.location.search;
 }
 
+export function isVisible(el: HTMLElement) {
+    try {
+      const rect = el.getBoundingClientRect();
+      if (rect.height === 0 && rect.width === 0) {
+        return false;
+      }
+      if (el.style.opacity === '0' || el.style.visibility === 'hidden') {
+        return false;
+      }
+    } catch {}
+    return true;
+}
+
 export function makeOpenInPopup(a: HTMLAnchorElement): void {
     a.onclick = () => !window.open(a.href, a.target, 'menubar=no,toolbar=no,location=no,dependent');
 }


### PR DESCRIPTION
## Description
This PR fixes https://github.com/gitpod-io/gitpod/issues/5179, which aims to make it possible with the extension to open Gitpod when in a repo and hitting the <kbd>.</kbd> key.

It is opt-out, so a new item in the settings was added:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/29888641/152583943-5f935fb4-d2cc-4a7b-9722-1b3e9c66ec99.png">


## How to test
Setup locally, load the extension into your browser and open a GitHub Repo, then hit the keybind, it should be enabled by default.

## Documentation

Maybe it would be good to have docs for this, although it is a very small feature.
