### PR TITLE
Suggestion: Open Chrome in a Preview Tab, with the extension loaded

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full-vnc
+
+RUN sudo apt-get update \
+    && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && sudo apt-get install -y ./google-chrome-stable_current_amd64.deb \
+    && rm google-chrome-stable_current_amd64.deb \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,21 @@
+image:
+  file: .gitpod.Dockerfile
 tasks:
-  - init: yarn install && yarn build && yarn package
+  - name: Google Chrome
+    command: >
+      gp sync-await start &&
+      gp await-port 6080 &&
+      for i in `seq 10 -1 1` ; do echo -ne "\rStarting Chrome in $i " && sleep 1 && echo -ne "\r" ; done &&
+      google-chrome --no-first-run --disable-dev-shm-usage --start-maximized --load-extension=/workspace/browser-extension https://github.com/gitpod-io/template-sveltekit
+  - name: Webpack Dev Server
+    init: yarn install && yarn build && yarn package
+    command: >
+      gp sync-done start &&
+      yarn watch
+ports:
+  - name: NoVNC
+    port: 6080
+    onOpen: open-preview
+  - name: Webpack Dev Server
+    port: 5900
+    onOpen: ignore


### PR DESCRIPTION
## Description

This PR changes `.gitpod.yml` to start the workspace with Chrome opened in the _Preview Tab_, with this extension loaded. So we can test it directly inside Gitpod.

![screencapture-gitpodio-browserextensio-d5rmblr4pdd-ws-eu30-gitpod-io-2022-02-07-21_14_01](https://user-images.githubusercontent.com/418083/152856765-392a9e4c-8e02-4076-bd31-0fe6db893b3c.png)

I originally made this change to be able to test https://github.com/gitpod-io/browser-extension/pull/54, but unfortunately, via _noVNC_, I was not able to trigger shortcuts (like "." to open Web IDE). That's why I decided to submit the change in a separate PR.

## Related Issue(s)

None.

## How to test

[Open this PR on Gitpod](https://gitpod.io/#https://github.com/gitpod-io/browser-extension/pull/55), and you will see Chrome opened in the _Preview Tab_. A GitHub tab will also be opened, and you'll see the Gitpod button there.

## Release Notes

```release-note
NONE
```

## Documentation

None.