### PR TITLE
change gitlab.cn SaaS domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
         "*://*.github.com/*",
         "*://*.gitlab.com/*",
         "*://*.bitbucket.org/*",
-        "*://*.gitlab.cn/*",
+        "*://*.jihulab.com/*",
         "*://*.gitpod.io/*"
       ],
       "js": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change gitlab.cn SaaS domain. The [SaaS version](http://jihulab.com/) of [`GitLab.cn`](https://gitlab.cn/en/) is now live. Due to legal and compliance requirements in China, we have changed the domain name of the SaaS version.

## Related Issue(s)

#45 
