### PR TITLE
[fix] fixes css issue in the browser extension

### DIFF
--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -77,6 +77,7 @@ abstract class ButtonInjectorBase implements ButtonInjector {
 
     inject(currentUrl: string, openAsPopup: boolean) {
         const actionbar = select(this.parentSelector);
+        console.log(this.parentSelector, 'acionbar github-injectorl, 80')
         if (!actionbar) {
             return;
         }
@@ -171,7 +172,7 @@ class IssueInjector extends ButtonInjectorBase {
 
 class FileInjector extends ButtonInjectorBase {
     constructor() {
-        super(".repository-content > div > div", "gitpod-file-btn");
+        super(".repository-content > div > div > div", "gitpod-file-btn");
     }
 
     protected adjustButton(a: HTMLAnchorElement): void {
@@ -199,7 +200,7 @@ class NavigationInjector extends ButtonInjectorBase {
 
 class EmptyRepositoryInjector extends ButtonInjectorBase {
     constructor() {
-        super(".repository-content", Gitpodify.CSS_REF_NO_CONTAINER, false, true);
+        super(".repository-content > div > git-clone-help > div > div ", "gitpod-file-btn", false, true);
     }
 
     protected adjustButton(a: HTMLAnchorElement): void {

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -77,7 +77,6 @@ abstract class ButtonInjectorBase implements ButtonInjector {
 
     inject(currentUrl: string, openAsPopup: boolean) {
         const actionbar = select(this.parentSelector);
-        console.log(this.parentSelector, 'acionbar github-injectorl, 80')
         if (!actionbar) {
             return;
         }


### PR DESCRIPTION
## Description
Fixes the CSS issue where the Gitpod button was broken on the page where you create a new repository and when you visit a specific file on GitHub

|Case 1: When you create a new repository | Case 2: When you visit a specific file |
| --- | --- |
|![Screenshot from 2022-05-05 22-34-39](https://user-images.githubusercontent.com/51204107/166976529-4066d2f7-d42b-49fc-8d70-f95de61289de.png) | ![Screenshot from 2022-05-05 22-35-52](https://user-images.githubusercontent.com/51204107/166978140-fc0ff8dd-1f63-4dfd-b70f-2a42ae817ee5.png) |
## Related Issue(s)
Fixes gitpod-io/gitpod#9435

