### PR TITLE
fix css when button is next to setup-in-desktop button

### DIFF
--- a/css/gitpodify.css
+++ b/css/gitpodify.css
@@ -6,6 +6,12 @@
 .file-navigation #gitpod-btn-container {
     margin-left: 6px;
 }
+/* Handle New Repository */
+.repository-content > div #gitpod-btn-container.gitpod-file-btn,
+.TableObject #gitpod-btn-container {
+    margin-left: 0px;
+    margin-right: 8px;
+}
 
 .no-container {
     margin-bottom: 10px;

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -203,7 +203,7 @@ class EmptyRepositoryInjector extends ButtonInjectorBase {
     }
 
     protected adjustButton(a: HTMLAnchorElement): void {
-        a.className = "btn btn-primary";
+        a.className = "btn btn-sm btn-primary";
     }
 
     isApplicableToCurrentPage(): boolean {


### PR DESCRIPTION
## Description
This is a follow-up PR to #60, to adjust the "Open in Gitpod" button for new repositories, when GitHub displays the "Set up in Desktop" button which seems to appear only in certain scenarios; I've tested using [Chrome in Gitpod](https://github.com/gitpod-io/browser-extension/blob/master/.gitpod.yml#L9) and this button wasn't visible. While testing locally, with Chrome in MacOC, I noticed the two buttons too close to each other.

|Before|After|
|---|---|
|<img width="862" alt="Screenshot 2022-05-06 at 09 24 50" src="https://user-images.githubusercontent.com/2318450/167088129-397c4af1-2569-4d7b-a9a1-210236a80a55.png">| <img width="862" alt="Screenshot 2022-05-06 at 12 34 59" src="https://user-images.githubusercontent.com/2318450/167115932-3b791286-084b-4345-be32-829157cec68e.png">|



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
https://github.com/gitpod-io/gitpod/issues/9817

## How to test
https://github.com/gitpod-io/browser-extension#test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix CSS for Gitpod button in GitHub added via Browser Extension
```
