### PR TITLE
added the button for `edit file in gitpod`

### DIFF
--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -8,7 +8,9 @@ namespace Gitpodify {
 	export const NAV_BTN_ID = "gitpod-btn-nav";
 	export const NAV_BTN_CLASS = "gitpod-nav-btn";
     export const NAV_BTN_CLASS_SELECTOR = "." + NAV_BTN_CLASS;
-    
+
+    export const EDIT_BTN_ID = "gitpod-edit-btn";
+
     export const CSS_REF_BTN_CONTAINER = "gitpod-btn-container";
     export const CSS_REF_NO_CONTAINER = "no-container";
 }
@@ -23,6 +25,7 @@ export class GitHubInjector extends InjectorBase {
             new PullInjector(),
             new IssueInjector(),
             new FileInjector(),
+            new EditFileButtonInjector(),
             new NavigationInjector(),
             new EmptyRepositoryInjector(),
         ]);
@@ -110,6 +113,20 @@ abstract class ButtonInjectorBase implements ButtonInjector {
             actionbar.appendChild(btn);
         }
 
+        // TODO: Render this button at correct place: In Dropdown menu of Edit Pencil Icon
+
+        const editBtn = this.renderEditButton(currentUrl, openAsPopup);
+        // const actionEditFile = document.getElementsByClassName("details-reset details-overlay select-menu BtnGroup-parent d-inline-block position-relative");
+        // const actionEditFileGroup = select(this.parentSelector);
+
+        // const editDropdown = Array.from(actionEditFileGroup.children)
+        //     .filter(child => child.className === "SelectMenu-list SelectMenu-list--borderless py-2");
+        
+        // actionEditFileGroup.insertBefore(editBtn, editDropdown[0]);
+        // actionEditFileGroup.insertBefore(editBtn, actionEditFile[0]);
+        // actionEditFileGroup.append(editBtn);
+        actionbar.appendChild(editBtn);
+
         const primaryButtons = actionbar.getElementsByClassName("btn-primary");
         if (primaryButtons && primaryButtons.length > 1) {
             Array.from(primaryButtons)
@@ -147,6 +164,21 @@ abstract class ButtonInjectorBase implements ButtonInjector {
     protected adjustButton(a: HTMLAnchorElement) {
         // do nothing
     }
+
+    protected renderEditButton(url: string, openAsPopup: boolean): HTMLElement {
+
+        const a = document.createElement('a');
+        a.id = Gitpodify.EDIT_BTN_ID;
+        a.title = "Edit this file in Gitpod";
+        a.text = "Open in Gitpod";
+        a.href = url;
+        a.target = "_blank";
+        if (openAsPopup) {
+            makeOpenInPopup(a);
+        }
+        a.className = "SelectMenu-item js-blob-dropdown-click width-full d-flex flex-justify-between color-fg-default f5 text-normal";
+        return a;
+    }
 }
 
 class PullInjector extends ButtonInjectorBase {
@@ -166,6 +198,15 @@ class IssueInjector extends ButtonInjectorBase {
 
     isApplicableToCurrentPage(): boolean {
 		return window.location.pathname.includes("/issues/");
+    }
+}
+
+class EditFileButtonInjector extends ButtonInjectorBase {
+    isApplicableToCurrentPage(): boolean {
+        return window.location.pathname.includes("/blob/");
+    }
+    constructor() {
+        super(".repository-content > div > div > readme-toc > div > div.Box-header.js-blob-header.blob-header.js-sticky.js-position-sticky.top-0.p-2.d-flex.flex-shrink-0.flex-md-row.flex-items-center > div.d-flex.py-1.py-md-0.flex-auto.flex-order-1.flex-md-order-2.flex-sm-grow-0.flex-justify-between.hide-sm.hide-md > div.d-flex > div.ml-1 > details > div > div > div", "gitpod-file-btn");
     }
 }
 

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -54,7 +54,6 @@ export class GitHubInjector extends InjectorBase {
 	    ghInjection(() => {
             if (!this.checkIsInjected()) {
                 this.injectButtons();
-                // this.editFileButton();
             }
             
             (async () => {
@@ -65,7 +64,6 @@ export class GitHubInjector extends InjectorBase {
 
     async update(): Promise<void> {
         this.injectButtons();
-        // this.editFileButton();
     }
 }
 

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -9,7 +9,7 @@ namespace Gitpodify {
 	export const NAV_BTN_CLASS = "gitpod-nav-btn";
     export const NAV_BTN_CLASS_SELECTOR = "." + NAV_BTN_CLASS;
 
-    export const EDIT_BTN_ID = "gitpod-edit-btn";
+    export const EDIT_BTN_ID = "gitpod-btn-file";
 
     export const CSS_REF_BTN_CONTAINER = "gitpod-btn-container";
     export const CSS_REF_NO_CONTAINER = "no-container";
@@ -54,6 +54,7 @@ export class GitHubInjector extends InjectorBase {
 	    ghInjection(() => {
             if (!this.checkIsInjected()) {
                 this.injectButtons();
+                // this.editFileButton();
             }
             
             (async () => {
@@ -64,6 +65,7 @@ export class GitHubInjector extends InjectorBase {
 
     async update(): Promise<void> {
         this.injectButtons();
+        // this.editFileButton();
     }
 }
 
@@ -113,26 +115,16 @@ abstract class ButtonInjectorBase implements ButtonInjector {
             actionbar.appendChild(btn);
         }
 
-        // TODO: Render this button at correct place: In Dropdown menu of Edit Pencil Icon
-
-        const editBtn = this.renderEditButton(currentUrl, openAsPopup);
-        // const actionEditFile = document.getElementsByClassName("details-reset details-overlay select-menu BtnGroup-parent d-inline-block position-relative");
-        // const actionEditFileGroup = select(this.parentSelector);
-
-        // const editDropdown = Array.from(actionEditFileGroup.children)
-        //     .filter(child => child.className === "SelectMenu-list SelectMenu-list--borderless py-2");
-        
-        // actionEditFileGroup.insertBefore(editBtn, editDropdown[0]);
-        // actionEditFileGroup.insertBefore(editBtn, actionEditFile[0]);
-        // actionEditFileGroup.append(editBtn);
-        actionbar.appendChild(editBtn);
-
         const primaryButtons = actionbar.getElementsByClassName("btn-primary");
         if (primaryButtons && primaryButtons.length > 1) {
             Array.from(primaryButtons)
-                .slice(0, primaryButtons.length - 1)
-                .forEach(primaryButton => primaryButton.classList.replace("btn-primary", "btn-secondary"));
+            .slice(0, primaryButtons.length - 1)
+            .forEach(primaryButton => primaryButton.classList.replace("btn-primary", "btn-secondary"));
         }
+
+        // Edit File Menu Options - Open in Gitpod
+        const editFileButton = document.querySelector('.Box-header .select-menu .SelectMenu-list') as ParentNode;
+        editFileButton.prepend(this.renderEditButton(currentUrl, openAsPopup));
     }
 
     protected renderButton(url: string, openAsPopup: boolean): HTMLElement {
@@ -166,7 +158,6 @@ abstract class ButtonInjectorBase implements ButtonInjector {
     }
 
     protected renderEditButton(url: string, openAsPopup: boolean): HTMLElement {
-
         const a = document.createElement('a');
         a.id = Gitpodify.EDIT_BTN_ID;
         a.title = "Edit this file in Gitpod";
@@ -202,11 +193,12 @@ class IssueInjector extends ButtonInjectorBase {
 }
 
 class EditFileButtonInjector extends ButtonInjectorBase {
+    constructor() {
+        super("", "gitpod-file-edit-btn");
+    }
+
     isApplicableToCurrentPage(): boolean {
         return window.location.pathname.includes("/blob/");
-    }
-    constructor() {
-        super(".repository-content > div > div > readme-toc > div > div.Box-header.js-blob-header.blob-header.js-sticky.js-position-sticky.top-0.p-2.d-flex.flex-shrink-0.flex-md-row.flex-items-center > div.d-flex.py-1.py-md-0.flex-auto.flex-order-1.flex-md-order-2.flex-sm-grow-0.flex-justify-between.hide-sm.hide-md > div.d-flex > div.ml-1 > details > div > div > div", "gitpod-file-btn");
     }
 }
 

--- a/src/injectors/injector.ts
+++ b/src/injectors/injector.ts
@@ -63,6 +63,18 @@ export abstract class InjectorBase implements Injector {
         }
     };
 
+    editFileButton(singleInjector: boolean = false){
+        const currentUrl = renderGitpodUrl(this.config.gitpodURL);
+        for (const injector of this.buttonInjectors) {
+            if (injector.isApplicableToCurrentPage()) {
+                injector.inject(currentUrl, this.config.openAsPopup);
+                if (singleInjector) {
+                    break;
+                }
+            }
+        }
+    };
+
     protected get config() {
         return this.configProvider.getConfig();
     }

--- a/src/injectors/injector.ts
+++ b/src/injectors/injector.ts
@@ -63,18 +63,6 @@ export abstract class InjectorBase implements Injector {
         }
     };
 
-    editFileButton(singleInjector: boolean = false){
-        const currentUrl = renderGitpodUrl(this.config.gitpodURL);
-        for (const injector of this.buttonInjectors) {
-            if (injector.isApplicableToCurrentPage()) {
-                injector.inject(currentUrl, this.config.openAsPopup);
-                if (singleInjector) {
-                    break;
-                }
-            }
-        }
-    };
-
     protected get config() {
         return this.configProvider.getConfig();
     }


### PR DESCRIPTION
## Description
This will add a menu option in edit file button.

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/10787

## How to test
- Open in Gitpod
- Run `yarn build && yarn package`
- Download Zip File
- Extract it & Load the unpacked version.
- Go to any file such as: [this file](https://github.com/gitpod-io/browser-extension/blob/master/README.md)
- Click on Edit Pencil ✏️ Icon

You Will See something like this: 
![image](https://user-images.githubusercontent.com/55068936/175647939-3273b724-7ed4-4e87-a363-8342e22bf90f.png)

<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->

## Release Notes

```release-note
! added the Open in Gitpod button to Edit File section for github.
```

## Documentation
 No
