### PR TITLE
fix(github): injection when editFileButton is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ For Chrome:
 For Firefox
 
 1. Open Firefox
-1. Click Preferences -> Extensions & Themes 
-1. Click on the cog icon -> Install Add-on From File -> Select the `gitpod.xpi` file
+1. Go to `about:debugging#/runtime/this-firefox`
+1. Click Load Temporary Add-on -> Select the `gitpod.xpi` file
 
 For Safari (Experimental 🧪)
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Gitpod - Always ready to code",
   "short_name": "Gitpod",
-  "version": "1.16",
+  "version": "1.17",
   "description": "Spin up fresh, automated dev environments for each task, in the cloud, in seconds.",
   "icons": {
     "16": "icons/gitpod-logo-16.png",

--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -122,7 +122,9 @@ abstract class ButtonInjectorBase implements ButtonInjector {
 
         // Edit File Menu Options - Open in Gitpod
         const editFileButton = document.querySelector('.Box-header .select-menu .SelectMenu-list') as ParentNode;
-        editFileButton.prepend(this.renderEditButton(currentUrl, openAsPopup));
+        if (editFileButton) {
+            editFileButton.prepend(this.renderEditButton(currentUrl, openAsPopup));
+        }
     }
 
     protected renderButton(url: string, openAsPopup: boolean): HTMLElement {


### PR DESCRIPTION
## Description
The injection is broken when `editFileButton` is null.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13609

## How to test
1. Start a workspace for this PR
2. Download the `gitpod.xpi` and install it
3. Open the GH PRs page, navigate to a PR
4. Observe that the button is rendered successfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Browser Extension] Button injection for GitHub not working when `editFileButton` is `null`
```
