### PR TITLE
Fix button spacing in issues and PRs for GitHub

### DIFF
--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -130,7 +130,7 @@ abstract class ButtonInjectorBase implements ButtonInjector {
     protected renderButton(url: string, openAsPopup: boolean): HTMLElement {
         let classes = this.btnClasses + ` ${Gitpodify.NAV_BTN_CLASS}`;
         if (this.float) {
-            classes = classes + ` float-right`;
+            classes = classes + ` float-right pr-1`;
         }
 
         const container = document.createElement('div');


### PR DESCRIPTION
## Description

Minor spacing fix for the button on GitHub Issues and PRs.

See [relevant discussion](https://gitpod.slack.com/archives/C020VCB0U5A/p1677169277384239) (internal). Cc @AlexTugarev 

## How to test

Open a workspace for this PR, wait for Chrome to open in Simple Browser and go to a GitHub issue or PR.

| BEFORE  | AFTER |
|-|-|
| ![button-before](https://user-images.githubusercontent.com/120486/220973879-e9d8eaf0-acfe-4919-a01d-52ea696db17a.png) | ![button-after](https://user-images.githubusercontent.com/120486/220973886-65d2164a-e38f-43d3-8480-0f87f78aade4.png) |