### PR TITLE
Trim gitpod url before open workspaces

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 export function renderGitpodUrl(gitpodURL: string): string {
     const baseURL = `${window.location.protocol}//${window.location.host}`;
-    return `${gitpodURL}/#${baseURL}` + window.location.pathname + window.location.search;
+    const trimmedUrl = gitpodURL.replace(/[\/]+$/g, '');
+    return `${trimmedUrl}/#${baseURL}` + window.location.pathname + window.location.search;
 }
 
 export function isVisible(el: HTMLElement) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixe if set Gitpod url as `https://gitpod.io/`

Click `Gitpod` button will jump to https://gitpod.io//#https://github.com/gitpod-io/gitpod gitpod homepage or not found

## How to test

- Open this PR with Gitpod
- Open VNC
- Change `Options > Gitpod URL` to `https://gitpod.io/`, visit github repo, hover link should correct

![image](https://user-images.githubusercontent.com/20944364/222079811-95fcc7f6-a2bb-4de8-b502-eb2cc661b8df.png)


