### PR TITLE
Fix for new navigation

### DIFF
--- a/src/injectors/github-injector.ts
+++ b/src/injectors/github-injector.ts
@@ -16,7 +16,15 @@ namespace Gitpodify {
 }
 
 function isNewNavigation(): boolean {
-    return !!select.exists(".pagehead-actions");
+    if (select.exists(".file-navigation")) {
+        return false;
+    }
+    const newNavigationFileHelperElement = 'button[data-hotkey="t,T"][hidden]';
+    if (select.exists(newNavigationFileHelperElement)) {
+        return true;
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
## Description
This enables the extension to work in the new GitHub navigation public beta. 

## Related Issue(s)

Fixes WEB-116

People noticing on Slack:
- https://gitpod.slack.com/archives/C01KPEPNBD0/p1681835561767419
- https://gitpod.slack.com/archives/C02EN94AEPL/p1681238833079259

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
