### PR TITLE
Proposal: Update "default_title" in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
       "48": "icons/gitpod-logo-48.png",
       "128": "icons/gitpod-logo.png"
     },
-    "default_title": "Gitpod Online IDE"
+    "default_title": "Gitpod CDEs"
   },
   "background": {
     "scripts": ["dist/bundles/background.bundle.js"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Changed `"Gitpod Online IDE"` -> `"Gitpod CDEs"`. If you have any other ideas, please feel free to suggest. Some possibilities:
- Just `Gitpod`, as most other extensions.
- `Gitpod - Always ready to code` as `"name"` in manifest.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
