### PR TITLE
Bring in Instance URL parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "crx-hotreload": "^1.0.6",
     "plasmo": "^0.83.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "validator": "^13.11.0"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "4.1.0",
@@ -31,6 +32,7 @@
     "@types/node": "20.5.0",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",
+    "@types/validator": "^13.11.1",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "chai": "^4.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  validator:
+    specifier: ^13.11.0
+    version: 13.11.0
 
 devDependencies:
   '@ianvs/prettier-plugin-sort-imports':
@@ -49,6 +52,9 @@ devDependencies:
   '@types/react-dom':
     specifier: 18.2.7
     version: 18.2.7
+  '@types/validator':
+    specifier: ^13.11.1
+    version: 13.11.1
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.7.0
     version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.1.6)
@@ -2487,6 +2493,10 @@ packages:
 
   /@types/semver@7.5.2:
     resolution: {integrity: sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==}
+    dev: true
+
+  /@types/validator@13.11.1:
+    resolution: {integrity: sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A==}
     dev: true
 
   /@types/yauzl@2.10.0:
@@ -6784,6 +6794,11 @@ packages:
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  /validator@13.11.0:
+    resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /vue@3.3.4:
     resolution: {integrity: sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==}

--- a/src/utils/parse-endpoint.ts
+++ b/src/utils/parse-endpoint.ts
@@ -1,0 +1,15 @@
+import isUrl from "validator/es/lib/isURL"
+
+export const parseEndpoint = (input: string): string => {
+  let url: URL
+
+  if (isUrl(input, { require_protocol: true, protocols: ["https"] })) {
+    url = new URL(input)
+  } else if (isUrl(input, { require_protocol: false, protocols: ["https"] })) {
+    url = new URL(`https://${input}`)
+  } else {
+    throw new TypeError(`Invalid URL: ${input}`)
+  }
+
+  return `${url.protocol}//${url.host}`
+}


### PR DESCRIPTION
## Description

Creates a better UX by allowing users to not only paste whatever URL from the Gitpod installation they'd like (it can be the user settings or new workspace page, doesn't matter), but also easier manual input by only needing the host without any protocols (we can assume it's always HTTPS).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-625

## How to test

Play around with the popup, it should accept different forms of URL inputs. 

