### PR TITLE
Update open with options menu

### DIFF
--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -23,7 +23,7 @@ export const GitpodButton = ({ application, additionalClassNames }: GitpodButton
     },
     {
       href: address + "/?autostart=false#" + window.location.toString(),
-      label: "Open with Options ...",
+      label: "Open with options...",
     },
   ]
   const dropdownRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
## Description

This will:
1. Change the Title Case to sentence case for the open with options menu. Title Case is great, but none of the Git providers is using it in the context of button area we use. Instead they rely on sentence case, which is also better in many other ways.
2. Append the ellipsis character ... directly after the text to keep the ellipsis closer to the word it's associated with, suggesting the continuity or additional options it represents.

![Frame 1904](https://github.com/gitpod-io/browser-extension/assets/120486/102fa13f-fc7b-4fd0-a3d0-3f3c85e14994)

/hold
