### PR TITLE
Default domain restriction

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: 'Release channel to publish to'
+        description: "Release channel to publish to"
         required: true
         type: choice
         options:
@@ -38,11 +38,13 @@ jobs:
       - name: Build the extension (Chrome)
         run: pnpm plasmo build --target=chrome-mv3
       - name: Build the extension (Firefox)
-        run: pnpm plasmo build --target=firefox-mv2
+        run: |
+          jq '.manifest.host_permissions = .manifest.optional_host_permissions | del(.manifest.optional_host_permissions)' package.json > temp.json && mv temp.json package.json # fix incomatibility with Chrome's MV3. See https://bugzilla.mozilla.org/show_bug.cgi?id=1766026
+          pnpm plasmo build --target=firefox-mv3
       - name: Package the extension into zip artifacts
-        run: | 
+        run: |
           pnpm package --target=chrome-mv3
-          pnpm package --target=firefox-mv2
+          pnpm package --target=firefox-mv3
       - name: Browser Platform Publish (staging)
         uses: PlasmoHQ/bpp@v3
         if: env.CHANNEL == 'staging'
@@ -50,7 +52,7 @@ jobs:
           keys: ${{ secrets.SUBMIT_KEYS_STAGING }}
           verbose: true
           chrome-file: build/chrome-mv3-prod.zip
-          firefox-file: build/firefox-mv2-prod.zip
+          firefox-file: build/firefox-mv3-prod.zip
       - name: Browser Platform Publish (production)
         uses: PlasmoHQ/bpp@v3
         if: env.CHANNEL == 'production'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/browser-extension)
 
-This is the browser extension for Gitpod. It supports Chrome (see [Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Firefox (see [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)) and Edge (see [how to install Chrome extensions](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)), and adds a **Gitpod** button to the configured GitLab, GitHub and Bitbucket installations (defaults to `gitlab.com`, `github.com`, `bitbucket.org`, and `gitlab.cn`) which immediately creates a Gitpod workspace for the current Git context:
+This is the browser extension for Gitpod. It supports Chrome (see [Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Firefox (see [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)) and Edge (see [how to install Chrome extensions](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)), and adds a **Gitpod** button to the configured GitLab, GitHub and Bitbucket installations (defaults to `gitlab.com`, `github.com` and `bitbucket.org`) which immediately creates a Gitpod workspace for the current git context:
 
 ![Gitpodify](./docs/github-injected.png "Gitpodify")
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,15 @@
     "plasmo": "^0.83.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "webext-additional-permissions": "^2.4.0",
+    "webext-content-scripts": "^2.5.5",
+    "webext-detect-page": "^4.1.1",
+    "webext-dynamic-content-scripts": "v9",
+    "webext-patterns": "^1.3.0",
+    "webext-polyfill-kinda": "^1.0.2",
+    "webext-tools": "^1.1.4",
+    "webextension-polyfill-ts": "^0.26.0"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "4.1.0",
@@ -51,8 +59,13 @@
     "typescript": "5.1.6"
   },
   "manifest": {
-    "host_permissions": [
-      "https://*/*"
+    "optional_host_permissions": [
+      "*://*/*"
+    ],
+    "permissions": [
+      "scripting",
+      "contextMenus",
+      "activeTab"
     ],
     "browser_specific_settings": {
       "gecko": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitpod",
   "displayName": "Gitpod",
-  "version": "2.0.3",
+  "version": "2.0.0",
   "description": "The developer platform for on-demand cloud development environments. Create software faster and more securely.",
   "author": "Gitpod <info@gitpod.io>",
   "homepage": "https://www.gitpod.io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitpod",
   "displayName": "Gitpod",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "The developer platform for on-demand cloud development environments. Create software faster and more securely.",
   "author": "Gitpod <info@gitpod.io>",
   "homepage": "https://www.gitpod.io",
@@ -69,7 +69,7 @@
     ],
     "browser_specific_settings": {
       "gecko": {
-        "id": "$FIREFOX_EXT_ID"
+        "id": "{24229a4f-eecc-47dc-abad-e47674ea8169}"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitpod",
   "displayName": "Gitpod",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The developer platform for on-demand cloud development environments. Create software faster and more securely.",
   "author": "Gitpod <info@gitpod.io>",
   "homepage": "https://www.gitpod.io",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,30 @@ dependencies:
   validator:
     specifier: ^13.11.0
     version: 13.11.0
+  webext-additional-permissions:
+    specifier: ^2.4.0
+    version: 2.4.0
+  webext-content-scripts:
+    specifier: ^2.5.5
+    version: 2.5.5
+  webext-detect-page:
+    specifier: ^4.1.1
+    version: 4.1.1
+  webext-dynamic-content-scripts:
+    specifier: v9
+    version: 9.2.2
+  webext-patterns:
+    specifier: ^1.3.0
+    version: 1.3.0
+  webext-polyfill-kinda:
+    specifier: ^1.0.2
+    version: 1.0.2
+  webext-tools:
+    specifier: ^1.1.4
+    version: 1.1.4
+  webextension-polyfill-ts:
+    specifier: ^0.26.0
+    version: 0.26.0
 
 devDependencies:
   '@ianvs/prettier-plugin-sort-imports':
@@ -3318,6 +3342,14 @@ packages:
       no-case: 3.0.4
       tslib: 2.6.2
       upper-case: 2.0.2
+    dev: false
+
+  /content-scripts-register-polyfill@3.2.2:
+    resolution: {integrity: sha512-3v/PSOWU/1F4zkIhnv3mIJUEUFaN2tEW8BHUv85q3OophSqJDLwo2Tj5DzoGCQ5N5iVYTeGO0eeR/NHrDcCnvQ==}
+    dependencies:
+      webext-content-scripts: 1.0.3
+      webext-patterns: 1.3.0
+      webext-polyfill-kinda: 0.10.0
     dev: false
 
   /content-security-policy-parser@0.4.1:
@@ -6963,6 +6995,75 @@ packages:
 
   /weak-lru-cache@1.2.2:
     resolution: {integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==}
+    dev: false
+
+  /webext-additional-permissions@2.4.0:
+    resolution: {integrity: sha512-u4g2taAPJZiwVftQek6pd7LfV6zuhMRRpsy/6SyAn2KBylbXKpY8KVVX7tOpJuuS6DMTLL5Fr49+p5e3SIX9YA==}
+    dependencies:
+      webext-patterns: 1.3.0
+    dev: false
+
+  /webext-content-scripts@1.0.3:
+    resolution: {integrity: sha512-Kwd6V/Dbbfl136e30aXd319IZPy3TvgKqqF834vlkOp/ALzEE8caPEbbjGHSQjt/zJVr3vtlUQOWP7GUH8WJlA==}
+    dependencies:
+      webext-polyfill-kinda: 0.10.0
+    dev: false
+
+  /webext-content-scripts@2.5.5:
+    resolution: {integrity: sha512-CIq1LA/nHIXE43v8qlpqNPcbsSzGuQBkeykbqOWvKJ1Rx/q7zgdZsLgxwyoonWiQcJczslVmGWCfdBY04JwIyw==}
+    engines: {node: '>=16'}
+    dependencies:
+      webext-patterns: 1.3.0
+      webext-polyfill-kinda: 1.0.2
+    dev: false
+
+  /webext-detect-page@4.1.1:
+    resolution: {integrity: sha512-s8DIJESB8Hv1YRT7Yrv42C5P/NJrnD7V/Es0UopWmaww5Ugc8qqkYXh9SYdAbxiNmsXWaHwwvjYEJopQ3cMfcg==}
+    dev: false
+
+  /webext-dynamic-content-scripts@9.2.2:
+    resolution: {integrity: sha512-fUmN7I5SaNzSNXrvXMMgjMKe7QvYFQ7XcYDyqcWxMF9jHhHiotERN51MwuFacJeQTgFni9vaR3HfYDG8RddeeQ==}
+    dependencies:
+      content-scripts-register-polyfill: 3.2.2
+      webext-additional-permissions: 2.4.0
+      webext-content-scripts: 2.5.5
+      webext-detect-page: 4.1.1
+      webext-patterns: 1.3.0
+      webext-polyfill-kinda: 0.10.0
+    dev: false
+
+  /webext-patterns@1.3.0:
+    resolution: {integrity: sha512-X9HMnic9ZtvSFKi2cdh0l+sxyj7f9oLedaa2JfxjnyEqGBz8OJjaHQ40jmraX1DJLTHOpqr+rCz1r3MW2+doUg==}
+    dependencies:
+      escape-string-regexp: 5.0.0
+    dev: false
+
+  /webext-polyfill-kinda@0.10.0:
+    resolution: {integrity: sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA==}
+    dev: false
+
+  /webext-polyfill-kinda@1.0.2:
+    resolution: {integrity: sha512-rqQUKeBTOicej0tjDJWDQlOTnDcm9yYJTzgI+7rMdyYV4QHmYMRm+yjkcVgECkg/Wu9MboZ4lYeBPdp1Ep9WgQ==}
+    dev: false
+
+  /webext-tools@1.1.4:
+    resolution: {integrity: sha512-z2M8TiAhQijCWXC71zzw0tQCTK/GFAo0OHobuz04AMyvGClETsufj0vBblYiXfxUkx+MDjYYWD2dTSebBiwcqQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      webext-content-scripts: 2.5.5
+      webext-detect-page: 4.1.1
+      webext-polyfill-kinda: 1.0.2
+    dev: false
+
+  /webextension-polyfill-ts@0.26.0:
+    resolution: {integrity: sha512-XEFL+aYVEsm/d4RajVwP75g56c/w2aSHnPwgtUv8/nCzbLNSzRQIix6aj1xqFkA5yr7OIDkk3OD/QTnPp8ThYA==}
+    deprecated: This project has moved to @types/webextension-polyfill
+    dependencies:
+      webextension-polyfill: 0.8.0
+    dev: false
+
+  /webextension-polyfill@0.8.0:
+    resolution: {integrity: sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==}
     dev: false
 
   /webidl-conversions@3.0.1:

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,1 +1,14 @@
+import { browser } from "webextension-polyfill-ts";
+import 'webext-dynamic-content-scripts';
+import addDomainPermissionToggle from "~utils/domain-accept";
+
+addDomainPermissionToggle();
+
+browser.runtime.onInstalled.addListener((details) => {
+    if (details.reason === "install") {
+        browser.tabs.create({ url: "https://www.gitpod.io/#extension-activation?track=true" });
+    }
+});
+browser.runtime.setUninstallURL("https://www.gitpod.io/#extension-uninstall?track=true");
+
 export { }

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,9 +6,9 @@ addDomainPermissionToggle();
 
 browser.runtime.onInstalled.addListener((details) => {
     if (details.reason === "install") {
-        browser.tabs.create({ url: "https://www.gitpod.io/#extension-activation?track=true" });
+        browser.tabs.create({ url: "https://www.gitpod.io/extension-activation?track=true" });
     }
 });
-browser.runtime.setUninstallURL("https://www.gitpod.io/#extension-uninstall?track=true");
+browser.runtime.setUninstallURL("https://www.gitpod.io/extension-uninstall?track=true");
 
 export { }

--- a/src/components/forms/Button.tsx
+++ b/src/components/forms/Button.tsx
@@ -1,0 +1,113 @@
+import classNames from "classnames"
+import React, {
+  forwardRef,
+  type FC,
+  type ForwardedRef,
+  type ReactNode
+} from "react"
+
+export type ButtonProps = {
+  type?: "primary" | "secondary" | "danger" | "danger.secondary" | "transparent"
+  size?: "small" | "medium" | "block"
+  spacing?: "compact" | "default"
+  disabled?: boolean
+  className?: string
+  autoFocus?: boolean
+  htmlType?: "button" | "submit" | "reset"
+  icon?: ReactNode
+  children?: ReactNode
+  onClick?: ButtonOnClickHandler
+}
+
+// Allow w/ or w/o handling event argument
+type ButtonOnClickHandler =
+  | React.DOMAttributes<HTMLButtonElement>["onClick"]
+  | (() => void)
+
+// eslint-disable-next-line react/display-name
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      type = "primary",
+      className,
+      htmlType = "button",
+      disabled = false,
+      autoFocus = false,
+      size,
+      spacing = "default",
+      icon,
+      children,
+      onClick
+    },
+    ref: ForwardedRef<HTMLButtonElement>
+  ) => {
+    return (
+      <button
+        type={htmlType}
+        className={classNames(
+          "cursor-pointer my-auto",
+          "text-sm font-medium whitespace-nowrap",
+          "rounded-xl focus:outline-none focus:ring transition ease-in-out",
+          spacing === "compact" ? ["px-1 py-1"] : null,
+          spacing === "default" ? ["px-4 py-2"] : null,
+          type === "primary"
+            ? [
+                "bg-gray-900 hover:bg-gray-800 dark:bg-kumquat-base dark:hover:bg-kumquat-ripe",
+                "text-gray-50 dark:text-gray-900"
+              ]
+            : null,
+          type === "secondary"
+            ? [
+                "bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600",
+                "text-gray-500 dark:text-gray-100 hover:text-gray-600"
+              ]
+            : null,
+          type === "danger"
+            ? ["bg-red-600 hover:bg-red-700", "text-gray-100 dark:text-red-100"]
+            : null,
+          type === "danger.secondary"
+            ? [
+                "bg-red-50 dark:bg-red-300 hover:bg-red-100 dark:hover:bg-red-200",
+                "text-red-600 hover:text-red-700"
+              ]
+            : null,
+          type === "transparent"
+            ? [
+                "bg-transparent hover:bg-gray-600 hover:bg-opacity-10 dark:hover:bg-gray-200 dark:hover:bg-opacity-10"
+              ]
+            : null,
+          {
+            "w-full": size === "block",
+            "cursor-default opacity-50 pointer-events-none": disabled
+          },
+          className
+        )}
+        ref={ref}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        onClick={onClick}>
+        <ButtonContent icon={icon}>{children}</ButtonContent>
+      </button>
+    )
+  }
+)
+
+// TODO: Consider making this a LoadingButton variant instead
+type ButtonContentProps = {
+  icon?: ReactNode
+  children?: ReactNode
+}
+const ButtonContent: FC<ButtonContentProps> = ({ icon, children }) => {
+  if (!icon) {
+    return <span>{children}</span>
+  }
+
+  return (
+    <div className="flex items-center justify-center space-x-2">
+      <span className="flex justify-center items-center w-5 h-5">
+        {icon ? icon : null}
+      </span>
+      {children && <span>{children}</span>}
+    </div>
+  )
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_GITPOD_ENDPOINT = "https://gitpod.io";
+export const ALL_ORIGINS_WILDCARD = "*://*/*";

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -1,16 +1,14 @@
+import cssText from "data-text:../button/button.css";
 import type { PlasmoCSConfig, PlasmoGetInlineAnchor } from "plasmo";
-import cssText from "data-text:../button/button.css"
-import { buttonContributions, type ButtonContributionParams, isSiteSuitable } from "../button/button-contributions";
+import React, { type ReactElement } from "react";
 import { GitpodButton } from "../button/button";
-import { type ReactElement } from "react";
-import React from "react";
+import { buttonContributions, isSiteSuitable, type ButtonContributionParams } from "../button/button-contributions";
 
 export const config: PlasmoCSConfig = {
   matches: [
     "https://github.com/*",
     "https://gitlab.com/*",
     "https://bitbucket.org/*",
-    "https://gitlab.cn/*",
   ]
 }
 

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -6,7 +6,10 @@ import { type ReactElement } from "react";
 import React from "react";
 
 export const config: PlasmoCSConfig = {
-  matches: ["<all_urls>"]
+  matches: ["https://github.com/*",
+    "https://gitlab.com/*",
+    "https://bitbucket.org/*",
+    "https://gitlab.cn/*",]
 }
 
 export const getStyle = () => {

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -6,10 +6,12 @@ import { type ReactElement } from "react";
 import React from "react";
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://github.com/*",
+  matches: [
+    "https://github.com/*",
     "https://gitlab.com/*",
     "https://bitbucket.org/*",
-    "https://gitlab.cn/*",]
+    "https://gitlab.cn/*",
+  ]
 }
 
 export const getStyle = () => {

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -1,8 +1,4 @@
 import type { PlasmoCSConfig } from "plasmo";
-import { Storage } from "@plasmohq/storage";
-import { STORAGE_AUTOMATICALLY_DETECT_GITPOD, STORAGE_KEY_ADDRESS } from "~storage";
-import { parseEndpoint } from "~utils/parse-endpoint";
-import { DEFAULT_GITPOD_ENDPOINT } from "~constants";
 
 /**
  * Checks if the current site is a Gitpod instance.
@@ -15,23 +11,6 @@ export const config: PlasmoCSConfig = {
   matches: ["https://gitpod.io/*"],
 }
 
-const storage = new Storage();
-
-const automaticallyUpdateEndpoint = async () => {
-  if (await storage.get<boolean>(STORAGE_AUTOMATICALLY_DETECT_GITPOD) === false) {
-    return;
-  }
-  
-  const currentUserSetEndpoint = await storage.get(STORAGE_KEY_ADDRESS);
-  if (!currentUserSetEndpoint || currentUserSetEndpoint === DEFAULT_GITPOD_ENDPOINT) {
-    const currentHost = window.location.host;
-    if (currentHost !== new URL(DEFAULT_GITPOD_ENDPOINT).host) {
-      console.log(`Gitpod extension: switching default endpoint to ${currentHost}.`)
-      await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(currentHost));
-    }
-  }
-}
 if (isSiteGitpod()) {
   sessionStorage.setItem("browser-extension-installed", "true");
-  automaticallyUpdateEndpoint();
 }

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -1,4 +1,8 @@
 import type { PlasmoCSConfig } from "plasmo";
+import { Storage } from "@plasmohq/storage";
+import { STORAGE_AUTOMATICALLY_DETECT_GITPOD, STORAGE_KEY_ADDRESS } from "~storage";
+import { parseEndpoint } from "~utils/parse-endpoint";
+import { DEFAULT_GITPOD_ENDPOINT } from "~constants";
 
 /**
  * Checks if the current site is a Gitpod instance.
@@ -15,6 +19,21 @@ export const config: PlasmoCSConfig = {
   ],
 }
 
+const storage = new Storage();
+
+const automaticallyUpdateEndpoint = async () => {
+  if (await storage.get<boolean>(STORAGE_AUTOMATICALLY_DETECT_GITPOD) === false) {
+    return;
+  }
+
+  const currentHost = window.location.host;
+  if (currentHost !== new URL(DEFAULT_GITPOD_ENDPOINT).host) {
+    console.log(`Gitpod extension: switching default endpoint to ${currentHost}.`)
+    await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(currentHost));
+  }
+}
+
 if (isSiteGitpod()) {
   sessionStorage.setItem("browser-extension-installed", "true");
+  automaticallyUpdateEndpoint();
 }

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -1,8 +1,8 @@
-import type { PlasmoCSConfig } from "plasmo";
 import { Storage } from "@plasmohq/storage";
+import type { PlasmoCSConfig } from "plasmo";
+import { DEFAULT_GITPOD_ENDPOINT } from "~constants";
 import { STORAGE_AUTOMATICALLY_DETECT_GITPOD, STORAGE_KEY_ADDRESS } from "~storage";
 import { parseEndpoint } from "~utils/parse-endpoint";
-import { DEFAULT_GITPOD_ENDPOINT } from "~constants";
 
 /**
  * Checks if the current site is a Gitpod instance.

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -12,7 +12,7 @@ const isSiteGitpod = (): boolean => {
 }
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://*/*"]
+  matches: ["https://gitpod.io/*"],
 }
 
 const storage = new Storage();

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -8,7 +8,11 @@ const isSiteGitpod = (): boolean => {
 }
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://gitpod.io/*", "https://*.gitpod.cloud/*"],
+  matches: [
+    "https://gitpod.io/*",
+    "https://*.gitpod.cloud/*",
+    "https://*.gitpod.dev/*"
+  ],
 }
 
 if (isSiteGitpod()) {

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -8,7 +8,7 @@ const isSiteGitpod = (): boolean => {
 }
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://gitpod.io/*"],
+  matches: ["https://gitpod.io/*", "https://*.gitpod.cloud/*"],
 }
 
 if (isSiteGitpod()) {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -23,7 +23,7 @@ const canAccessOrigin = async (origin: string) => {
 function IndexPopup() {
   const [error, setError] = useState<string>();
 
-  const [storedAddress, setStoredAddress] = useStorage<string>(STORAGE_KEY_ADDRESS, "https://gitpod.io");
+  const [storedAddress, setStoredAddress] = useStorage<string>(STORAGE_KEY_ADDRESS, DEFAULT_GITPOD_ENDPOINT);
   const [address, setAddress] = useState<string>(storedAddress);
   const updateAddress = useCallback(async () => {
     try {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -7,6 +7,7 @@ import { useStorage } from "@plasmohq/storage/hook";
 
 import { ALL_ORIGINS_WILDCARD, DEFAULT_GITPOD_ENDPOINT } from "~constants";
 import {
+  STORAGE_AUTOMATICALLY_DETECT_GITPOD,
   STORAGE_KEY_ADDRESS,
   STORAGE_KEY_ALWAYS_OPTIONS,
   STORAGE_KEY_NEW_TAB
@@ -82,6 +83,11 @@ function IndexPopup() {
     false
   );
 
+  const [enableInstanceHopping, setEnableInstanceHopping] = useStorage<boolean>(
+    STORAGE_AUTOMATICALLY_DETECT_GITPOD,
+    true
+  );
+
   return (
     <div
       style={{
@@ -128,6 +134,12 @@ function IndexPopup() {
           hint="Changes the primary button to always open with options"
           checked={disableAutostart}
           onChange={setDisableAutostart}
+        />
+        <CheckboxInputField
+          label="Automatic instance hopping"
+          hint="Changes the Gitpod URL automatically when a Gitpod Dedicated instance is detected"
+          checked={enableInstanceHopping}
+          onChange={setEnableInstanceHopping}
         />
       </form>
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,17 +1,17 @@
-import "./popup.css"
 import React, { useCallback, useEffect, useState, type FormEvent } from "react";
 import { browser } from "webextension-polyfill-ts";
+import "./popup.css";
 
-import { useStorage } from "@plasmohq/storage/hook";
 import { Storage } from "@plasmohq/storage";
+import { useStorage } from "@plasmohq/storage/hook";
 
+import { ALL_ORIGINS_WILDCARD, DEFAULT_GITPOD_ENDPOINT } from "~constants";
 import {
   STORAGE_KEY_ADDRESS,
   STORAGE_KEY_ALWAYS_OPTIONS,
   STORAGE_KEY_NEW_TAB
 } from "~storage";
 import { hostToOrigin, parseEndpoint } from "~utils/parse-endpoint";
-import { ALL_ORIGINS_WILDCARD, DEFAULT_GITPOD_ENDPOINT } from "~constants";
 import { canAccessAllSites, canAccessOrigin } from "~utils/permissions";
 
 import { Button } from "~components/forms/Button";

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -107,7 +107,7 @@ function IndexPopup() {
         />
         <CheckboxInputField
           label="Run on all sites"
-          hint="Automatically add buttons for any detected self-hosted provider and Gitpod Dedicated"
+          hint="Automatically add buttons for any detected self-hosted SCM provider"
           checked={allSites}
           onChange={async (checked) => {
             if (checked) {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -93,7 +93,7 @@ function IndexPopup() {
       <form className="w-full" onSubmit={updateAddress} action="#">
         <InputField
           label="Gitpod URL"
-          hint={`Gitpod instance URL, e.g. ${DEFAULT_GITPOD_ENDPOINT}.`}
+          hint={`Gitpod instance URL, e.g., ${DEFAULT_GITPOD_ENDPOINT}.`}
           topMargin={false}>
           <div className="flex w-full max-w-sm items-center space-x-2">
             <TextInput value={address} onChange={setAddress} />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -9,6 +9,7 @@ import { InputField } from "~components/forms/InputField";
 import { TextInput } from "~components/forms/TextInputField";
 import { CheckboxInputField } from "~components/forms/CheckboxInputField";
 import { DEFAULT_GITPOD_ENDPOINT } from "~constants";
+import { browser } from "webextension-polyfill-ts";
 
 function IndexPopup() {
   const [error, setError] = useState<string>();
@@ -33,6 +34,8 @@ function IndexPopup() {
 
   const [openInNewTab, setOpenInNewTab] = useStorage<boolean>(STORAGE_KEY_NEW_TAB, true);
   const [automaticallyDetect, setAutomaticallyDetect] = useStorage<boolean>(STORAGE_AUTOMATICALLY_DETECT_GITPOD, true);
+
+  const [allSites, setAllSites] = useState(false);
 
   return (
     <div
@@ -69,6 +72,16 @@ function IndexPopup() {
           hint="Upon visiting a Gitpod Dedicated instance, switch to it"
           checked={automaticallyDetect}
           onChange={setAutomaticallyDetect}
+        />
+        <CheckboxInputField
+          label="Run on all sites"
+          hint="Automatically add buttons for any detected self-hosted provider and Gitpod Dedicated"
+          checked={allSites}
+          onChange={(checked) => {
+            if (checked) {
+              browser.permissions.request({ origins: ["*://*/*"] })
+            }
+          }}
         />
       </form>
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,3 @@
 
 export const STORAGE_KEY_ADDRESS = "gitpod-installation-address";
 export const STORAGE_KEY_NEW_TAB = "gitpod-installation-new-tab";
-export const STORAGE_AUTOMATICALLY_DETECT_GITPOD = "gitpod-installation-automatically-detect-gitpod";

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,5 @@
 
 export const STORAGE_KEY_ADDRESS = "gitpod-installation-address";
 export const STORAGE_KEY_NEW_TAB = "gitpod-installation-new-tab";
+export const STORAGE_AUTOMATICALLY_DETECT_GITPOD = "gitpod-installation-automatically-detect-gitpod";
 export const STORAGE_KEY_ALWAYS_OPTIONS = "gitpod-installation-always-options";

--- a/src/utils/domain-accept.ts
+++ b/src/utils/domain-accept.ts
@@ -1,0 +1,191 @@
+// This is all code adapted from https://github.com/fregante/webext-domain-permission-toggle/pull/24.
+// todo: when the PR is merged, remove this file and use the package instead.
+
+import chromeP from 'webext-polyfill-kinda';
+import {patternToRegex} from 'webext-patterns';
+import {isBackground} from 'webext-detect-page';
+import {getManifestPermissionsSync} from 'webext-additional-permissions';
+import {getTabUrl} from 'webext-tools';
+import {executeFunction} from 'webext-content-scripts';
+
+const contextMenuId = 'webext-domain-permission-toggle:add-permission';
+let globalOptions: Options;
+
+type Options = {
+	/**
+	 * The title of the action in the context menu.
+	 */
+	title?: string;
+
+	/**
+	 * If the user accepts the new permission, they will be asked to reload the current tab.
+	 * Set a `string` to customize the message and `false` (default) to avoid the reload and its request.
+	 */
+	reloadOnSuccess?: string | boolean;
+};
+
+async function isOriginPermanentlyAllowed(origin: string): Promise<boolean> {
+	return chromeP.permissions.contains({
+		origins: [origin + '/*'],
+	});
+}
+
+async function updateItem(url?: string): Promise<void> {
+	const settings = {
+		checked: false,
+		enabled: true,
+	};
+
+	// No URL means no activeTab, no manifest permission, no granted permission, or no permission possible (chrome://)
+	if (url) {
+		const origin = new URL(url).origin;
+		// Manifest permissions can't be removed; this disables the toggle on those domains
+		const manifestPermissions = getManifestPermissionsSync();
+		const isDefault = patternToRegex(...manifestPermissions.origins).test(origin);
+		settings.enabled = !isDefault;
+
+		// We might have temporary permission as part of `activeTab`, so it needs to be properly checked
+		settings.checked = isDefault || await isOriginPermanentlyAllowed(origin);
+	}
+
+	chrome.contextMenus.update(contextMenuId, settings);
+}
+
+async function togglePermission(tab: chrome.tabs.Tab, toggle: boolean): Promise<void> {
+	// Don't use non-ASCII characters because Safari breaks the encoding in executeScript.code
+	const safariError = 'The browser didn\'t supply any information about the active tab.';
+	if (!tab.url && toggle) {
+		throw new Error(`Please try again. ${safariError}`);
+	}
+
+	if (!tab.url && !toggle) {
+		throw new Error(`Couldn't disable the extension on the current tab. ${safariError}`);
+	}
+
+	// TODO: Ensure that URL is in `optional_permissions`
+	const permissionData = {
+		origins: [
+			new URL(tab.url!).origin + '/*',
+		],
+	};
+
+	if (!toggle) {
+		void chromeP.permissions.remove(permissionData);
+		return;
+	}
+
+	const userAccepted = await chromeP.permissions.request(permissionData);
+	if (!userAccepted) {
+		chrome.contextMenus.update(contextMenuId, {
+			checked: false,
+		});
+		return;
+	}
+
+	if (globalOptions.reloadOnSuccess) {
+		void executeFunction(tab.id!, (message: string) => {
+			if (confirm(message)) {
+				location.reload();
+			}
+		}, globalOptions.reloadOnSuccess);
+	}
+}
+
+async function handleTabActivated({tabId}: chrome.tabs.TabActiveInfo): Promise<void> {
+	void updateItem(await getTabUrl(tabId) ?? '');
+}
+
+async function handleClick(
+	{checked, menuItemId}: chrome.contextMenus.OnClickData,
+	tab?: chrome.tabs.Tab,
+): Promise<void> {
+	if (menuItemId !== contextMenuId) {
+		return;
+	}
+
+	try {
+		await togglePermission(tab!, checked!);
+	} catch (error) {
+		if (tab?.id) {
+			try {
+				await executeFunction(
+					tab.id,
+					text => {
+						alert(text); /* Can't pass a raw native function */
+					},
+					String(error),
+				);
+			} catch {
+				alert(error); // One last attempt
+			}
+		}
+
+		throw error;
+	} finally {
+		void updateItem();
+	}
+}
+
+/**
+ * Adds an item to the browser action icon's context menu.
+ * The user can access this menu by right clicking the icon. If your extension doesn't have any action or
+ * popup assigned to the icon, it will also appear with a left click.
+ *
+ * @param options {Options}
+ */
+export default function addDomainPermissionToggle(options?: Options): void {
+	if (!isBackground()) {
+		throw new Error('webext-domain-permission-toggle can only be called from a background page');
+	}
+
+	if (globalOptions) {
+		throw new Error('webext-domain-permission-toggle can only be initialized once');
+	}
+
+	const {name, permissions, optional_host_permissions: optionalPermissions} = chrome.runtime.getManifest();
+
+	if (!permissions?.includes('contextMenus')) {
+		throw new Error('webext-domain-permission-toggle requires the `contextMenus` permission');
+	}
+
+	if (!chrome.contextMenus) {
+		console.warn('chrome.contextMenus is not available');
+		return;
+	}
+
+	globalOptions = {
+		title: `Enable ${name} on this domain`,
+		reloadOnSuccess: false,
+		...options,
+	};
+
+	if (globalOptions.reloadOnSuccess === true) {
+		globalOptions.reloadOnSuccess = `Do you want to reload this page to apply ${name}?`;
+	}
+
+	const optionalHosts = optionalPermissions?.filter(permission => /<all_urls>|\*/.test(permission));
+	if (!optionalHosts || optionalHosts.length === 0) {
+		throw new TypeError('webext-domain-permission-toggle requires some wildcard hosts to be specified in `optional_permissions`');
+	}
+
+	chrome.contextMenus.remove(contextMenuId, () => chrome.runtime.lastError);
+	chrome.contextMenus.create({
+		id: contextMenuId,
+		type: 'checkbox',
+		checked: false,
+		title: globalOptions.title,
+		contexts: 'browser_action' in chrome ?
+			['page_action', 'browser_action']:
+			['action'],
+		// Note: This is completely ignored by Chrome and Safari. Great. #14
+		documentUrlPatterns: optionalHosts,
+	});
+
+	chrome.contextMenus.onClicked.addListener(handleClick);
+	chrome.tabs.onActivated.addListener(handleTabActivated);
+	chrome.tabs.onUpdated.addListener(async (tabId, {status}, {url, active}) => {
+		if (active && status === 'complete') {
+			void updateItem(url ?? await getTabUrl(tabId) ?? '');
+		}
+	});
+}

--- a/src/utils/parse-endpoint.ts
+++ b/src/utils/parse-endpoint.ts
@@ -13,3 +13,9 @@ export const parseEndpoint = (input: string): string => {
 
   return `${url.protocol}//${url.host}`
 }
+
+export const hostToOrigin = (host: string): string => {
+  const url = new URL(host)
+
+  return url.origin + "/*";
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,10 @@
+import { browser } from "webextension-polyfill-ts";
+import { ALL_ORIGINS_WILDCARD } from "~constants";
+
+export const canAccessAllSites = async () => {
+    return await browser.permissions.contains({ origins: [ALL_ORIGINS_WILDCARD] });
+}
+
+export const canAccessOrigin = async (origin: string) => {
+    return await browser.permissions.contains({ origins: [origin] });
+}


### PR DESCRIPTION
Do not request all domains by default, let the user enable the integration everywhere. 

- The default origins, which are required for the extension to work, are:
	- `https://github.com`
	- `https://gitlab.com`
	- `https://bitbucket.org`
	- `https://gitpod.io`
	- `https://*.gitpod.dev`
	- `https://*.gitpod.cloud`
- This also updates the permissions to include `scripting`, `contextMenus` and `activeTab`, but none of these require user prompts.
- Additionally, updating the Gitpod URL requests the corresponding hostname to be allowed as well.
- Support for the automatic detection of Gitpod Dedicated has been removed, because it did not make sense to keep with the permission changes


## How to test

- Remove the extension if you've had it before (necessary for permissions reset) and update it with a newly built one
- Visit our [Bitbucket Datacenter instance](https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/browse) and see the extension does not inject any buttons
- Open the context menu of the Gitpod extension and enable it on the domain. If required, refresh the tab and see the button appear.