### PR TITLE
[Bitbucket] commits view

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -391,7 +391,7 @@ export const buttonContributions: ButtonContributionParams[] = [
       id: "bb-commits",
       match: /\/commits\/(.+)?/,
       exampleUrls: [
-        // "https://bitbucket.org/efftinge/browser-extension-test/commits/"
+        "https://bitbucket.org/efftinge/browser-extension-test/commits/"
       ],
       selector: 'xpath://*[@id="root"]/div[2]/div[3]/div/div/div[1]/div/div/div[1]/div[1]/div[2]/div',
       containerElement: createElement("div", {

--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -321,7 +321,7 @@ export const buttonContributions: ButtonContributionParams[] = [
     // Bitbucket Server
     {
       id: "bbs-repo",
-      match: /\/browse/,
+      match: /\/(browse|commits)/,
       exampleUrls: [
         "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/browse",
         "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/browse?at=refs%2Fheads%2Fmy-branch",
@@ -333,7 +333,6 @@ export const buttonContributions: ButtonContributionParams[] = [
       }),
       application: "bitbucket-server",
       additionalClassNames: ["secondary"],
-    
     },
     {
       id: "bbs-pull-request",
@@ -348,7 +347,7 @@ export const buttonContributions: ButtonContributionParams[] = [
       }),
       application: "bitbucket-server",
     },
-    
+
     // bitbucket.org
     // we use xpath expressions, because the CSS selectors are not stable enough
     // tests are disabled because the URLs are not reachable without a session

--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -318,7 +318,7 @@ export const buttonContributions: ButtonContributionParams[] = [
       ]
       
     },
-    // BitBucket Server
+    // Bitbucket Server
     {
       id: "bbs-repo",
       match: /\/browse/,
@@ -338,7 +338,7 @@ export const buttonContributions: ButtonContributionParams[] = [
     {
       id: "bbs-pull-request",
       exampleUrls: [
-        // disabled becaus it doesn't work anonymously
+        // disabled because it doesn't work anonymously
         // "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/pull-requests/1/overview",
       ],
       selector: "#pull-requests-container > header > div.pull-request-header-bar > div.pull-request-actions",
@@ -350,8 +350,8 @@ export const buttonContributions: ButtonContributionParams[] = [
     },
     
     // bitbucket.org
-    // we use xpath epressions, because the CSS selectors are not stable enough
-    // tests are disabled because the URLs are not rechable without a session
+    // we use xpath expressions, because the CSS selectors are not stable enough
+    // tests are disabled because the URLs are not reachable without a session
     {
       id: "bb-repo",
       exampleUrls: [
@@ -382,6 +382,18 @@ export const buttonContributions: ButtonContributionParams[] = [
         // "https://bitbucket.org/efftinge/browser-extension-test/branch/my-branch"
       ],
       selector: 'xpath://*[@id="root"]/div[2]/div[3]/div/div/div[1]/div/div/div[2]/div/div',
+      containerElement: createElement("div", {
+        marginLeft: "2px",
+      }),
+      application: "bitbucket",
+    },
+    {
+      id: "bb-commits",
+      match: /\/commits\/(.+)?/,
+      exampleUrls: [
+        // "https://bitbucket.org/efftinge/browser-extension-test/commits/"
+      ],
+      selector: 'xpath://*[@id="root"]/div[2]/div[3]/div/div/div[1]/div/div/div[1]/div[1]/div[2]/div',
       containerElement: createElement("div", {
         marginLeft: "2px",
       }),

--- a/test/src/button-contributions-copy.ts
+++ b/test/src/button-contributions-copy.ts
@@ -321,7 +321,7 @@ export const buttonContributions: ButtonContributionParams[] = [
     // Bitbucket Server
     {
       id: "bbs-repo",
-      match: /\/browse/,
+      match: /\/(browse|commits)/,
       exampleUrls: [
         "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/browse",
         "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/browse?at=refs%2Fheads%2Fmy-branch",
@@ -333,7 +333,6 @@ export const buttonContributions: ButtonContributionParams[] = [
       }),
       application: "bitbucket-server",
       additionalClassNames: ["secondary"],
-    
     },
     {
       id: "bbs-pull-request",
@@ -348,7 +347,7 @@ export const buttonContributions: ButtonContributionParams[] = [
       }),
       application: "bitbucket-server",
     },
-    
+
     // bitbucket.org
     // we use xpath expressions, because the CSS selectors are not stable enough
     // tests are disabled because the URLs are not reachable without a session

--- a/test/src/button-contributions-copy.ts
+++ b/test/src/button-contributions-copy.ts
@@ -318,7 +318,7 @@ export const buttonContributions: ButtonContributionParams[] = [
       ]
       
     },
-    // BitBucket Server
+    // Bitbucket Server
     {
       id: "bbs-repo",
       match: /\/browse/,
@@ -338,7 +338,7 @@ export const buttonContributions: ButtonContributionParams[] = [
     {
       id: "bbs-pull-request",
       exampleUrls: [
-        // disabled becaus it doesn't work anonymously
+        // disabled because it doesn't work anonymously
         // "https://bitbucket.gitpod-dev.com/users/svenefftinge/repos/browser-extension-test/pull-requests/1/overview",
       ],
       selector: "#pull-requests-container > header > div.pull-request-header-bar > div.pull-request-actions",
@@ -350,8 +350,8 @@ export const buttonContributions: ButtonContributionParams[] = [
     },
     
     // bitbucket.org
-    // we use xpath epressions, because the CSS selectors are not stable enough
-    // tests are disabled because the URLs are not rechable without a session
+    // we use xpath expressions, because the CSS selectors are not stable enough
+    // tests are disabled because the URLs are not reachable without a session
     {
       id: "bb-repo",
       exampleUrls: [
@@ -382,6 +382,18 @@ export const buttonContributions: ButtonContributionParams[] = [
         // "https://bitbucket.org/efftinge/browser-extension-test/branch/my-branch"
       ],
       selector: 'xpath://*[@id="root"]/div[2]/div[3]/div/div/div[1]/div/div/div[2]/div/div',
+      containerElement: createElement("div", {
+        marginLeft: "2px",
+      }),
+      application: "bitbucket",
+    },
+    {
+      id: "bb-commits",
+      match: /\/commits\/(.+)?/,
+      exampleUrls: [
+        "https://bitbucket.org/efftinge/browser-extension-test/commits/"
+      ],
+      selector: 'xpath://*[@id="root"]/div[2]/div[3]/div/div/div[1]/div/div/div[1]/div[1]/div[2]/div',
       containerElement: createElement("div", {
         marginLeft: "2px",
       }),


### PR DESCRIPTION
## Description

This adds a <kbd>Gitpod</kbd> button to the commits view on https://bitbucket.org.

<img width="1552" alt="image" src="https://github.com/gitpod-io/browser-extension/assets/29888641/268a227d-3e43-4b4a-a53e-02367f222f89">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-777
Fixes EXP-769 (https://github.com/gitpod-io/browser-extension/pull/103/commits/30ecb6ae44a8b7a4d7444820d66449a286ec1a3b)
