### PR TITLE
Fix GitHub turbo transitions

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -202,7 +202,7 @@ export const buttonContributions: ButtonContributionParams[] = [
             "https://github.com/svenefftinge/browser-extension-test",
             "https://github.com/svenefftinge/browser-extension-test/tree/my-branch",
         ],
-        selector: `xpath://*[@id="repo-content-pjax-container"]/div/div/div[2]/div[1]/react-partial/div/div/div[2]/div[2]`,
+        selector: `xpath://*[contains(@id, 'repo-content-')]/div/div/div[2]/div[1]/react-partial/div/div/div[2]/div[2]`,
         containerElement: createElement("div", {}),
         additionalClassNames: ["medium"],
         application: "github",


### PR DESCRIPTION
## Description

GitHub renders the DOM differently depending on whether you have landed on the page as a result of a hard browser refresh or simply because of GitHub's built-in SPA-like navigation between tabs. This fixes the selector to allow for both cases.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes EXP-1490

## How to test

1. In a GitHub repo, ensure the Gitpod button is injected.
2. Go to the issues page
3. Click back. The Gitpod button should still be there (it used to disappear)
