### PR TITLE
Fix PRs on bitbucket.org

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -343,10 +343,17 @@ export const buttonContributions: ButtonContributionParams[] = [
         exampleUrls: [
             // "https://bitbucket.org/efftinge/browser-extension-test/pull-requests/1"
         ],
-        selector: 'xpath://*[@id="pull-request-details"]/header/div/div/div[2]/div/div[2]/div/div/div',
-        containerElement: createElement("div", {
-            marginLeft: "2px",
-        }),
+        selector: 'xpath://*[@id="root"]/div[3]/div[3]/div/div/div[1]/div/div/div[1]/div/div[2]/div/div[2]/div[1]',
+        containerElement: createElement("div", {}),
+        manipulations: [
+            {
+                element: 'xpath://*[@id="root"]/div[3]/div[3]/div/div/div[1]/div/div/div[1]/div/div[2]/div/div[2]/div',
+                style: {
+                    display: "flex",
+                    gap: "0.25rem",
+                },
+            },
+        ],
         application: "bitbucket",
     },
     {

--- a/test/src/button-contributions-copy.ts
+++ b/test/src/button-contributions-copy.ts
@@ -343,10 +343,17 @@ export const buttonContributions: ButtonContributionParams[] = [
         exampleUrls: [
             // "https://bitbucket.org/efftinge/browser-extension-test/pull-requests/1"
         ],
-        selector: 'xpath://*[@id="pull-request-details"]/header/div/div/div[2]/div/div[2]/div/div/div',
-        containerElement: createElement("div", {
-            marginLeft: "2px",
-        }),
+        selector: 'xpath://*[@id="root"]/div[3]/div[3]/div/div/div[1]/div/div/div[1]/div/div[2]/div/div[2]/div[1]',
+        containerElement: createElement("div", {}),
+        manipulations: [
+            {
+                element: 'xpath://*[@id="root"]/div[3]/div[3]/div/div/div[1]/div/div/div[1]/div/div[2]/div/div[2]/div',
+                style: {
+                    display: "flex",
+                    gap: "0.25rem",
+                },
+            },
+        ],
         application: "bitbucket",
     },
     {


### PR DESCRIPTION
## Description

Fixes DOM selectors for the button to work again.

<img width="855" alt="image" src="https://github.com/gitpod-io/browser-extension/assets/29888641/4c8058fb-d9ad-4bfb-85ef-5db5c4cdb1ae">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C05K08WRCQ7/p1718961638080739?thread_ts=1715697272.914219&cid=C05K08WRCQ7

## How to test

https://bitbucket.org/efftinge/browser-extension-test/pull-requests/1
