### PR TITLE
Fix Bitbucket.org PR selectors

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -410,9 +410,9 @@ export const buttonContributions: ButtonContributionParams[] = [
         exampleUrls: [
             // "https://bitbucket.org/efftinge/browser-extension-test/pull-requests/1"
         ],
-        selector: 'xpath://*[@id="main"]/div/div/div[1]/div/div/div[1]/div/div[2]/div/div[2]/div/div', // grandparent div of the "Request changes" and "Approve" buttons
+        selector: 'xpath://*[@id="main"]/div/div/div[1]/div/div/div/div[1]/div/div[2]/div/div[2]/div/div', // grandparent div of the "Request changes" and "Approve" buttons
         containerElement: createElement("div", {}),
-        insertBefore: 'xpath:(//*[@id="main"]/div/div/div[1]/div/div/div[1]/div/div[2]/div/div[2]/div/div/div)[last()]', // note the [last()] to insert before the last child (the kebab menu)
+        insertBefore: 'xpath:(//*[@id="main"]/div/div/div[1]/div/div/div/div[1]/div/div[2]/div/div[2]/div/div/div)[last()]', // note the [last()] to insert before the last child (the kebab menu)
         application: "bitbucket",
     },
     {


### PR DESCRIPTION
## Description

Fixes the Pull Request selectors due to recent changes from the SCM.

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/2e76e5f6-9352-42e5-bae3-87e148e03675">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1022

## How to test

https://bitbucket.org/efftinge/browser-extension-test/pull-requests/1