### PR TITLE
Update CSS selector for base repository on gitlab.com

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,8 @@ image:
 tasks:
   - name: install node version
     init: |
+      sudo apt update
+      sudo apt install -y nodejs
       nvm install 20
       nvm use 20
       nvm uninstall 16

--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -191,7 +191,7 @@ export const buttonContributions: ButtonContributionParams[] = [
         ],
         // must not match /blob/ because that is a file
         match: /^(?!.*\/blob\/).*$/,
-        selector: "#tree-holder > div > div.tree-controls > div:first-child",
+        selector: "#tree-holder .tree-controls",
         containerElement: { type: "div", props: { marginLeft: "8px" } },
         application: "gitlab",
         manipulations: [

--- a/test/src/button-contributions-copy.ts
+++ b/test/src/button-contributions-copy.ts
@@ -191,7 +191,7 @@ export const buttonContributions: ButtonContributionParams[] = [
         ],
         // must not match /blob/ because that is a file
         match: /^(?!.*\/blob\/).*$/,
-        selector: "#tree-holder > div > div.tree-controls > div:first-child",
+        selector: "#tree-holder .tree-controls",
         containerElement: { type: "div", props: { marginLeft: "8px" } },
         application: "gitlab",
         manipulations: [

--- a/test/src/button-contributions.spec.ts
+++ b/test/src/button-contributions.spec.ts
@@ -10,8 +10,8 @@ describe("Platform match tests", function () {
 
     before(async function () {
         browser = await puppeteer.launch({
-            headless: "new",
-            product: "chrome",
+            headless: true,
+            browser: "chrome",
         });
         page = await browser.newPage();
     });
@@ -66,8 +66,8 @@ describe("Query Selector Tests", function () {
 
     before(async function () {
         browser = await puppeteer.launch({
-            headless: "new",
-            product: "chrome",
+            headless: true,
+            browser: "chrome",
         });
         page = await browser.newPage();
     });
@@ -78,7 +78,7 @@ describe("Query Selector Tests", function () {
 
     async function resolveSelector(page: Page, selector: string) {
         if (selector.startsWith("xpath:")) {
-            return (await page.$x(selector.slice(6)))[0] || null;
+            return (await (page as any).$x(selector.slice(6)))[0] || null;
         } else {
             return page.$(selector);
         }


### PR DESCRIPTION
## Description
This Pull Request fixes a broken CSS selector that caused the "Open" button to not appear on the base repository view on GitLab. The MR view worked properly still.

## How to test

The tests were updated to address puppeteer version changes (and one typescript oddity). Using `pnpm build` and `pnpm package` on firefox now requires using Firefox Developer Edition due to package signature requirements.

/hold

Fixes CLC-1116
