### PR TITLE
Fix selectors for new GitHub issue design

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -92,7 +92,7 @@ export interface ButtonContributionParams {
     /**
      * Additional class names that should be added to the elements.
      */
-    additionalClassNames?: ("secondary" | "medium" | "left-align-menu")[];
+    additionalClassNames?: ("secondary" | "medium" | "left-align-menu" | "tall")[];
 
     /**
      * A selector that is used to insert the button before a specific element.
@@ -301,7 +301,7 @@ export const buttonContributions: ButtonContributionParams[] = [
     },
 
     {
-        id: "gh-issues",
+        id: "gh-issue",
         exampleUrls: ["https://github.com/svenefftinge/browser-extension-test/issues/1"],
         selector: "#partial-discussion-header > div.gh-header-show > div > div",
         containerElement: createElement("div", {
@@ -319,7 +319,17 @@ export const buttonContributions: ButtonContributionParams[] = [
         ],
     },
     {
-        id: "gh-pulls",
+        id: "gh-issue-new", // this isn't referring to "new issue", but to new "issue"
+        exampleUrls: ["https://github.com/svenefftinge/browser-extension-test/issues/1"],
+        selector: `xpath://*[@id="js-repo-pjax-container"]/react-app/div/div/div/div/div[1]/div/div/div[3]/div`,
+        containerElement: createElement("div", {}),
+        insertBefore: `xpath://*[@id="js-repo-pjax-container"]/react-app/div/div/div/div/div[1]/div/div/div[3]/div/div`,
+        application: "github",
+        // we need to make the button higher: the buttons here use 2rem instead of 1.75rem
+        additionalClassNames: ["tall"],
+    },
+    {
+        id: "gh-pull",
         exampleUrls: ["https://github.com/svenefftinge/browser-extension-test/pull/2"],
         selector: "#partial-discussion-header > div.gh-header-show > div > div",
         containerElement: createElement("div", {

--- a/src/button/button.css
+++ b/src/button/button.css
@@ -209,6 +209,10 @@
     --dropdown-box-shadow: var(--shadow-floating-large, var(--color-shadow-large));
 }
 
+.github.tall {
+    --primary-height: var(--control-medium-size, 2rem);
+}
+
 .github .chevron-icon {
     padding: 3px;
 }


### PR DESCRIPTION
## Description

GitHub has been further rewriting their interface in React and now all[^1] users are now enrolled in the [new GitHub issues UI](https://github.blog/changelog/2025-01-13-evolving-github-issues-public-preview/) by default.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1142

## How to test

Go to https://github.com/svenefftinge/browser-extension-test/issues/1 with a fresh compiled extension from this branch.

/hold
