### PR TITLE
Enable automatic instance hopping for Flex

### DIFF
--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -14,7 +14,7 @@ const isSiteGitpod = (): boolean => {
 };
 
 export const config: PlasmoCSConfig = {
-    matches: ["https://gitpod.io/*", "https://*.gitpod.cloud/*"],
+    matches: ["https://gitpod.io/*", "https://app.gitpod.io/*", "https://*.gitpod.cloud/*"],
 };
 
 const storage = new Storage();
@@ -32,7 +32,7 @@ const automaticallyUpdateEndpoint = async () => {
             !currentlyStoredEndpoint
         ) {
             console.log(`Gitpod extension: switching default endpoint to ${currentHost}.`);
-            await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(currentHost));
+            await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(window.location.href));
         }
     }
 };

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -32,7 +32,7 @@ const automaticallyUpdateEndpoint = async () => {
             !currentlyStoredEndpoint
         ) {
             console.log(`Gitpod extension: switching default endpoint to ${currentHost}.`);
-            await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(window.location.href));
+            await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(window.location.origin));
         }
     }
 };


### PR DESCRIPTION
## Description

For an easier migration to Flex, automatically change the Gitpod host to `app.gitpod.io` when users visit it.

Sister PR to https://github.com/gitpod-io/gitpod-next/pull/5806.
