### PR TITLE
Set an explicit default Gitpod host for existing users

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,5 @@
         "overrides": {
             "sharp": "0.33.4"
         }
-    },
-    "packageManager": "pnpm@9.14.2"
+    }
 }

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -17,7 +17,7 @@ type Props = {
     urlTransformer?: (url: string) => string;
 };
 export const GitpodButton = ({ application, additionalClassNames, urlTransformer }: Props) => {
-    const [address] = useStorage<string>(STORAGE_KEY_ADDRESS, DEFAULT_GITPOD_ENDPOINT);
+    const [address, setAddress] = useStorage<string>(STORAGE_KEY_ADDRESS);
     const [openInNewTab] = useStorage<boolean>(STORAGE_KEY_NEW_TAB, true);
     const [disableAutostart] = useStorage<boolean>(STORAGE_KEY_ALWAYS_OPTIONS, false);
     const [showDropdown, setShowDropdown] = useState(false);
@@ -36,6 +36,13 @@ export const GitpodButton = ({ application, additionalClassNames, urlTransformer
             document.removeEventListener(EVENT_CURRENT_URL_CHANGED, handleUrlChange);
         };
     }, []);
+
+    // if the user has no address configured, set it to the default endpoint
+    useEffect(() => {
+        if (!address) {
+            setAddress(DEFAULT_GITPOD_ENDPOINT);
+        }
+    }, [address]);
 
     const actions = useMemo(() => {
         const parsedHref = !urlTransformer ? currentHref : urlTransformer(currentHref);

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -48,7 +48,7 @@ export const GitpodButton = ({ application, additionalClassNames, urlTransformer
                 await storage.set(STORAGE_KEY_ADDRESS, DEFAULT_GITPOD_ENDPOINT);
             }
         })();
-    }, [address]);
+    }, []);
 
     const actions = useMemo(() => {
         const parsedHref = !urlTransformer ? currentHref : urlTransformer(currentHref);

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -4,6 +4,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import Logo from "react:./logo-mark.svg";
 
 import { useStorage } from "@plasmohq/storage/hook";
+import { Storage } from "@plasmohq/storage";
 
 import { DEFAULT_GITPOD_ENDPOINT, EVENT_CURRENT_URL_CHANGED } from "~constants";
 import { STORAGE_KEY_ADDRESS, STORAGE_KEY_ALWAYS_OPTIONS, STORAGE_KEY_NEW_TAB } from "~storage";
@@ -17,7 +18,7 @@ type Props = {
     urlTransformer?: (url: string) => string;
 };
 export const GitpodButton = ({ application, additionalClassNames, urlTransformer }: Props) => {
-    const [address, setAddress] = useStorage<string>(STORAGE_KEY_ADDRESS);
+    const [address] = useStorage<string>(STORAGE_KEY_ADDRESS);
     const [openInNewTab] = useStorage<boolean>(STORAGE_KEY_NEW_TAB, true);
     const [disableAutostart] = useStorage<boolean>(STORAGE_KEY_ALWAYS_OPTIONS, false);
     const [showDropdown, setShowDropdown] = useState(false);
@@ -39,9 +40,14 @@ export const GitpodButton = ({ application, additionalClassNames, urlTransformer
 
     // if the user has no address configured, set it to the default endpoint
     useEffect(() => {
-        if (!address) {
-            setAddress(DEFAULT_GITPOD_ENDPOINT);
-        }
+        (async () => {
+            // we don't use the useStorage hook because it does not offer a way see if the value is set (it could just be loading), meaning we could end up setting the default endpoint even if it's already set
+            const storage = new Storage();
+            const persistedAddress = await storage.get(STORAGE_KEY_ADDRESS);
+            if (!persistedAddress) {
+                await storage.set(STORAGE_KEY_ADDRESS, DEFAULT_GITPOD_ENDPOINT);
+            }
+        })();
     }, [address]);
 
     const actions = useMemo(() => {

--- a/src/contents/gitpod-dashboard.ts
+++ b/src/contents/gitpod-dashboard.ts
@@ -1,8 +1,5 @@
-import type { PlasmoCSConfig } from "plasmo";
-
 import { Storage } from "@plasmohq/storage";
-
-import { DEFAULT_GITPOD_ENDPOINT } from "~constants";
+import type { PlasmoCSConfig } from "plasmo";
 import { STORAGE_AUTOMATICALLY_DETECT_GITPOD, STORAGE_KEY_ADDRESS } from "~storage";
 import { parseEndpoint } from "~utils/parse-endpoint";
 
@@ -25,15 +22,10 @@ const automaticallyUpdateEndpoint = async () => {
     }
 
     const currentHost = window.location.host;
-    if (currentHost !== new URL(DEFAULT_GITPOD_ENDPOINT).host) {
-        const currentlyStoredEndpoint = await storage.get<string>(STORAGE_KEY_ADDRESS);
-        if (
-            (currentlyStoredEndpoint && new URL(currentlyStoredEndpoint).host !== currentHost) ||
-            !currentlyStoredEndpoint
-        ) {
-            console.log(`Gitpod extension: switching default endpoint to ${currentHost}.`);
-            await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(window.location.origin));
-        }
+    const currentlyStoredEndpoint = await storage.get<string>(STORAGE_KEY_ADDRESS);
+    if (!currentlyStoredEndpoint || new URL(currentlyStoredEndpoint).host !== currentHost) {
+        console.log(`Gitpod extension: switching default endpoint to ${currentHost}.`);
+        await storage.set(STORAGE_KEY_ADDRESS, parseEndpoint(window.location.origin));
     }
 };
 


### PR DESCRIPTION
## Description

Preps for NEXT-3410 by making sure all users who use the extension get their host set to https://gitpod.io, if they haven't set it to something else manually.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes NEXT-3408

## How to test

1. Make a fresh install of the extension
2. In Chrome, go into `Application` -> `Extension storage` -> `Gitpod` -> `Sync` and see the value is set to `"https://gitpod.io"`. If not, go to a page the extension is active on (such as this PR) and see again.

The rollout plan here is to let the extension explicitly set the hostname for a couple of weeks and then roll out a new version where the default is `app.gitpod.io`.
