### PR TITLE
Change default endpoint to `app.gitpod.io`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gitpod Browser extension
 
-[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/browser-extension)
+[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://app.gitpod.io/#https://github.com/gitpod-io/browser-extension)
 
-This is the browser extension for Gitpod. It supports Chrome (see [Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Firefox (see [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)) and Edge (see [how to install Chrome extensions](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)), and adds a **Gitpod** button to the configured GitLab, GitHub and Bitbucket installations (defaults to `gitlab.com`, `github.com` and `bitbucket.org`) which immediately creates a Gitpod workspace for the current git context:
+This is the browser extension for Gitpod. It supports Chrome (see [Chrome Web Store](https://chrome.google.com/webstore/detail/dodmmooeoklaejobgleioelladacbeki/)), Firefox (see [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/gitpod/)) and Edge (see [how to install Chrome extensions](https://support.microsoft.com/help/4538971/microsoft-edge-add-or-remove-extensions)), and adds a **Gitpod** button to the configured GitLab, GitHub, Bitbucket and Azure DevOps installations (defaults to `gitlab.com`, `github.com`, `bitbucket.org` and `dev.azure.com`) which immediately creates a Gitpod workspace for the current git context:
 
 ![Gitpodify](./docs/github-injected.png "Gitpodify")
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_GITPOD_ENDPOINT = "https://gitpod.io";
+export const DEFAULT_GITPOD_ENDPOINT = "https://app.gitpod.io";
 export const ALL_ORIGINS_WILDCARD = "*://*/*";
 export const EVENT_CURRENT_URL_CHANGED = "current-url-changed";


### PR DESCRIPTION
## Description

Shifts new users from classic to https://app.gitpod.io

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes NEXT-3410

## How to test

Try installing the dev version in Chrome and checking the used endpoint.
