### PR TITLE
[github] fix for new PR review experience

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -326,6 +326,19 @@ export const buttonContributions: ButtonContributionParams[] = [
         application: "github",
     },
     {
+        // `prx_files` is the new PR review experience on GitHub
+        id: "gh-pull-prx_files",
+        exampleUrls: [
+            // "https://github.com/svenefftinge/browser-extension-test/pull/2/files" // this is an experiment for now, and we can't test against GitHub's feature flags yet
+        ],
+        selector: "div[data-component='PH_Actions']",
+        containerElement: createElement("div", {
+            order: "2",
+        }),
+        match: /\/pull\//,
+        application: "github",
+    },
+    {
         id: "gh-file",
         exampleUrls: ["https://github.com/svenefftinge/browser-extension-test/blob/my-branch/README.md"],
         selector: "#StickyHeader > div > div > div.Box-sc-g0xbh4-0.gtBUEp",


### PR DESCRIPTION
## Description

As GitHub rolls out [its new pull request review experience](https://github.blog/changelog/2025-07-31-pull-request-files-changed-public-preview-experience-july-31-updates/), we'll want our extension to support it. This PR addresses that

<img width="1388" height="1070" alt="image" src="https://github.com/user-attachments/assets/766c58e7-c006-40ca-8c1b-56dd4320c25c" />

## How to test

1. Run the extension in dev mode (`pnpm run dev`) and install it unpacked in a Chromium-based browser
2. Go to a PR on GitHub and click on the "Files changed" tab
3. Make sure you're enrolled in the new experience (there should be a button on the PR review page to enroll)
4. Observe the Gitpod button is present