### PR TITLE
[github] fix selector for github.com PR page

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -318,7 +318,7 @@ export const buttonContributions: ButtonContributionParams[] = [
     {
         id: "gh-pull",
         exampleUrls: ["https://github.com/svenefftinge/browser-extension-test/pull/2"],
-        selector: "#partial-discussion-header > div.gh-header-show > div > div",
+        selector: "#partial-discussion-header div.gh-header-show > div > div",
         containerElement: createElement("div", {
             order: "2",
         }),


### PR DESCRIPTION
## Description

Fixes PRs on GitHub. This is relevant for all pages besides the file review page, which now has an experimental new design.