### PR TITLE
[github.com] Code button-anchored selector

### DIFF
--- a/src/button/button-contributions.ts
+++ b/src/button/button-contributions.ts
@@ -263,7 +263,12 @@ export const buttonContributions: ButtonContributionParams[] = [
             "https://github.com/svenefftinge/browser-extension-test",
             "https://github.com/svenefftinge/browser-extension-test/tree/my-branch",
         ],
-        selector: `xpath://*[contains(@id, 'repo-content-')]/div/div/div/div[1]/react-partial/div/div/div[2]/div[2]`,
+        // The parent of the "Code" button (matched by text or icon)
+        selector: `xpath:(
+          //div[contains(@class,'repository-content')]//button[.//span[normalize-space()='Code']]
+          | 
+          //div[contains(@class,'repository-content')]//button[.//*[contains(concat(' ', normalize-space(@class), ' '), ' octicon-code ')]]
+        )/parent::div`,
         containerElement: createContainerElement("div", {}),
         additionalClassNames: ["medium"],
         application: "github",


### PR DESCRIPTION
## Description

Fixes based on reports we got of the main repo selector failing to match, likely due to upstream GitHub changes.

The change entails stopping the game of catching exact selectors, and basically just selecting whatever parent the "Code" button has as the target for button injection.

![CleanShot 2026-02-27 at 10 26 51@2x](https://github.com/user-attachments/assets/543cc482-80eb-4e14-bef7-d728fa618aa3)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CORE-7339
